### PR TITLE
Limit the rationalizer history view

### DIFF
--- a/marshal/claim_test.go
+++ b/marshal/claim_test.go
@@ -236,6 +236,8 @@ func (s *ClaimSuite) TestCommitOutstanding(c *C) {
 	msg1 := s.consumeOne(c)
 	c.Assert(msg1.Value, DeepEquals, []byte("m1"))
 	c.Assert(s.cl.Commit(msg1), IsNil)
+	// TODO: There's a race here. If the background goroutine decides to run a health check
+	// here it will consume our offset and this test fails. It's rare but possible.
 	c.Assert(s.cl.numTrackingOffsets(), Equals, 6)
 	c.Assert(s.cl.offsets.Current, Equals, int64(0))
 

--- a/marshal/message.go
+++ b/marshal/message.go
@@ -49,6 +49,7 @@ const (
 
 type message interface {
 	Encode() string
+	Timestamp() int
 	Type() msgType
 }
 
@@ -142,6 +143,11 @@ func (m *msgBase) Type() msgType {
 	panic("Attempted to type the base message. This should never happen.")
 }
 
+// Timestamp returns the timestamp of the message
+func (m *msgBase) Timestamp() int {
+	return m.Time
+}
+
 // msgHeartbeat is sent regularly by all consumers to re-up their claim to the partition that
 // they're consuming.
 type msgHeartbeat struct {
@@ -159,6 +165,11 @@ func (m *msgHeartbeat) Type() msgType {
 	return msgTypeHeartbeat
 }
 
+// Timestamp returns the timestamp of the message
+func (m *msgHeartbeat) Timestamp() int {
+	return m.Time
+}
+
 // msgClaimingPartition is used in the claim flow.
 type msgClaimingPartition struct {
 	msgBase
@@ -172,6 +183,11 @@ func (m *msgClaimingPartition) Encode() string {
 // Type returns the type of this message.
 func (m *msgClaimingPartition) Type() msgType {
 	return msgTypeClaimingPartition
+}
+
+// Timestamp returns the timestamp of the message
+func (m *msgClaimingPartition) Timestamp() int {
+	return m.Time
 }
 
 // msgReleasingPartition is used in a controlled shutdown to indicate that you are done with
@@ -191,6 +207,11 @@ func (m *msgReleasingPartition) Type() msgType {
 	return msgTypeReleasingPartition
 }
 
+// Timestamp returns the timestamp of the message
+func (m *msgReleasingPartition) Timestamp() int {
+	return m.Time
+}
+
 // msgClaimingMessages is used for at-most-once consumption semantics, this is a pre-commit
 // advisory message.
 type msgClaimingMessages struct {
@@ -206,4 +227,9 @@ func (m *msgClaimingMessages) Encode() string {
 // Type returns the type of this message.
 func (m *msgClaimingMessages) Type() msgType {
 	return msgTypeClaimingMessages
+}
+
+// Timestamp returns the timestamp of the message
+func (m *msgClaimingMessages) Timestamp() int {
+	return m.Time
 }

--- a/marshal/message.go
+++ b/marshal/message.go
@@ -138,7 +138,7 @@ func (m *msgBase) Encode() string {
 }
 
 // Type returns the type of this message.
-func (m *msgBase) Type() {
+func (m *msgBase) Type() msgType {
 	panic("Attempted to type the base message. This should never happen.")
 }
 

--- a/marshal/rationalizer.go
+++ b/marshal/rationalizer.go
@@ -21,116 +21,135 @@ import (
 func (w *Marshaler) kafkaConsumerChannel(partID int) <-chan message {
 	log.Debugf("rationalize[%d]: starting", partID)
 	out := make(chan message, 1000)
-	go func() {
-		var err error
-		var alive bool
-		var offsetFirst, offsetNext int64
+	go w.consumeFromKafka(partID, out, false)
+	return out
+}
 
-		retry := &backoff.Backoff{Min: 500 * time.Millisecond, Jitter: true}
-		for ; true; time.Sleep(retry.Duration()) {
-			// Figure out how many messages are in this topic. This can fail if the broker handling
-			// this partition is down, so we will loop.
-			offsetFirst, err = w.kafka.OffsetEarliest(MarshalTopic, int32(partID))
-			if err != nil {
-				log.Errorf("rationalize[%d]: failed to get offset: %s", partID, err)
-				continue
-			}
-			offsetNext, err = w.kafka.OffsetLatest(MarshalTopic, int32(partID))
-			if err != nil {
-				log.Errorf("rationalize[%d]: failed to get offset: %s", partID, err)
-				continue
-			}
-			log.Debugf("rationalize[%d]: offsets %d to %d", partID, offsetFirst, offsetNext)
+// consumeFromKafka will start consuming messages from Kafka and writing them to the given
+// channel forever.
+func (w *Marshaler) consumeFromKafka(partID int, out chan message, startOldest bool) {
+	var err error
+	var alive bool
+	var offsetFirst, offsetNext int64
 
-			// TODO: Is there a case where the latest offset is X>0 but there is no data in
-			// the partition? does the offset reset to 0?
-			if offsetNext == 0 || offsetFirst == offsetNext {
-				alive = true
-				w.rationalizers.Done()
-			}
-			break
+	retry := &backoff.Backoff{Min: 500 * time.Millisecond, Jitter: true}
+	for ; true; time.Sleep(retry.Duration()) {
+		// Figure out how many messages are in this topic. This can fail if the broker handling
+		// this partition is down, so we will loop.
+		offsetFirst, err = w.kafka.OffsetEarliest(MarshalTopic, int32(partID))
+		if err != nil {
+			log.Errorf("rationalize[%d]: failed to get offset: %s", partID, err)
+			continue
 		}
-		retry.Reset()
+		offsetNext, err = w.kafka.OffsetLatest(MarshalTopic, int32(partID))
+		if err != nil {
+			log.Errorf("rationalize[%d]: failed to get offset: %s", partID, err)
+			continue
+		}
+		log.Debugf("rationalize[%d]: offsets %d to %d", partID, offsetFirst, offsetNext)
 
-		// TODO: Technically we don't have to start at the beginning, we just need to start back
-		// a couple heartbeat intervals to get a full state of the world. But this is easiest
-		// for right now...
-		// TODO: Think about the above. Is it actually true?
-		consumerConf := kafka.NewConsumerConf(MarshalTopic, int32(partID))
-		consumerConf.StartOffset = kafka.StartOffsetOldest
-		consumerConf.RequestTimeout = 1 * time.Second
+		// TODO: Is there a case where the latest offset is X>0 but there is no data in
+		// the partition? does the offset reset to 0?
+		if offsetNext == 0 || offsetFirst == offsetNext {
+			alive = true
+			w.rationalizers.Done()
+		}
+		break
+	}
+	retry.Reset()
 
-		// Get the offsets of this partition, we're going to arbitrarily pick something that
-		// is ~100,000 from the end if there's more than that.
-		offsets, err := w.GetPartitionOffsets(MarshalTopic, partID)
-		if offsets.Latest-offsets.Earliest > 100000 {
-			consumerConf.StartOffset = offsets.Latest - 100000
+	// Assume we're starting at the oldest offset for consumption
+	consumerConf := kafka.NewConsumerConf(MarshalTopic, int32(partID))
+	consumerConf.StartOffset = kafka.StartOffsetOldest
+	consumerConf.RequestTimeout = 1 * time.Second
+
+	// Get the offsets of this partition, we're going to arbitrarily pick something that
+	// is ~100,000 from the end if there's more than that. This is only if startOldest is
+	// false, i.e., we didn't run into a "message too new" situation.
+	checkMessageTs := false
+	if !startOldest {
+		if offsetNext-offsetFirst > 100000 {
+			checkMessageTs = true
+			consumerConf.StartOffset = offsetNext - 100000
 			log.Infof("rationalize[%d]: fast forwarding to offset %d.",
 				partID, consumerConf.StartOffset)
 		}
+	}
 
-		consumer, err := w.kafka.Consumer(consumerConf)
-		if err != nil {
-			// Unfortunately this is a fatal error, as without being able to consume this partition
-			// we can't effectively rationalize.
-			log.Fatalf("rationalize[%d]: Failed to create consumer: %s", partID, err)
+	consumer, err := w.kafka.Consumer(consumerConf)
+	if err != nil {
+		// Unfortunately this is a fatal error, as without being able to consume this partition
+		// we can't effectively rationalize.
+		log.Fatalf("rationalize[%d]: Failed to create consumer: %s", partID, err)
+	}
+
+	// Consume messages forever, or until told to quit.
+	for {
+		if atomic.LoadInt32(w.quit) == 1 {
+			log.Debugf("rationalize[%d]: terminating.", partID)
+			close(out)
+			return
 		}
 
-		// Consume messages forever, or until told to quit.
-		for {
-			if atomic.LoadInt32(w.quit) == 1 {
-				log.Debugf("rationalize[%d]: terminating.", partID)
-				close(out)
-				return
-			}
+		msgb, err := consumer.Consume()
+		if err != nil {
+			// The internal consumer will do a number of retries. If we get an error here,
+			// we're probably in the middle of a partition handoff. We should pause so we
+			// don't hammer the cluster, but otherwise continue.
+			log.Warningf("rationalize[%d]: failed to consume: %s", partID, err)
+			time.Sleep(retry.Duration())
+			continue
+		}
+		retry.Reset()
 
-			msgb, err := consumer.Consume()
-			if err != nil {
-				// The internal consumer will do a number of retries. If we get an error here,
-				// we're probably in the middle of a partition handoff. We should pause so we
-				// don't hammer the cluster, but otherwise continue.
-				log.Warningf("rationalize[%d]: failed to consume: %s", partID, err)
-				time.Sleep(retry.Duration())
-				continue
-			}
-			retry.Reset()
+		msg, err := decode(msgb.Value)
+		if err != nil {
+			// Invalid message in the stream. This should never happen, but if it does, just
+			// continue on.
+			// TODO: We should probably think about this. If we end up in a situation where
+			// one version of this software has a bug that writes invalid messages, it could
+			// be doing things we don't anticipate. Of course, crashing all consumers
+			// reading that partition is also bad.
+			log.Errorf("rationalize[%d]: %s", partID, err)
 
-			msg, err := decode(msgb.Value)
-			if err != nil {
-				// Invalid message in the stream. This should never happen, but if it does, just
-				// continue on.
-				// TODO: We should probably think about this. If we end up in a situation where
-				// one version of this software has a bug that writes invalid messages, it could
-				// be doing things we don't anticipate. Of course, crashing all consumers
-				// reading that partition is also bad.
-				log.Errorf("rationalize[%d]: %s", partID, err)
-
-				// In the case where the first message is an invalid message, we need to
-				// to notify that we're alive now
-				if !alive {
-					alive = true
-					w.rationalizers.Done()
-				}
-				continue
-			}
-
-			log.Debugf("rationalize[%d]: @%d: [%s]", partID, msgb.Offset, msg.Encode())
-			out <- msg
-
-			// This is a one-time thing that fires the first time the rationalizer comes up
-			// and makes sure we actually process all of the messages.
-			if !alive && msgb.Offset >= offsetNext-1 {
-				for len(out) > 0 {
-					time.Sleep(100 * time.Millisecond)
-				}
-				log.Infof("rationalize[%d]: reached offset %d, now alive",
-					partID, msgb.Offset)
+			// In the case where the first message is an invalid message, we need to
+			// to notify that we're alive now
+			if !alive {
 				alive = true
 				w.rationalizers.Done()
 			}
+			continue
 		}
-	}()
-	return out
+
+		// If we are on our first message, and we started at a non-zero offset, we need
+		// to check to make sure that the timestamp is older than a given threshold. If it's
+		// too new, that indicates our 100000 try didn't work, so let's go from the start.
+		// TODO: This could be a binary search or something.
+		if checkMessageTs {
+			if int64(msg.(*msgBase).Time) > time.Now().Unix()-HeartbeatInterval*2 {
+				log.Warningf("rationalize[%d]: rewinding, fast-forwarded message was too new",
+					partID)
+				go w.consumeFromKafka(partID, out, true)
+				return // terminate self.
+			}
+			checkMessageTs = false
+		}
+
+		log.Debugf("rationalize[%d]: @%d: [%s]", partID, msgb.Offset, msg.Encode())
+		out <- msg
+
+		// This is a one-time thing that fires the first time the rationalizer comes up
+		// and makes sure we actually process all of the messages.
+		if !alive && msgb.Offset >= offsetNext-1 {
+			for len(out) > 0 {
+				time.Sleep(100 * time.Millisecond)
+			}
+			log.Infof("rationalize[%d]: reached offset %d, now alive",
+				partID, msgb.Offset)
+			alive = true
+			w.rationalizers.Done()
+		}
+	}
 }
 
 // updateClaim is called whenever we need to adjust a claim structure.


### PR DESCRIPTION
This makes the rationalizers only go back 100000 offsets. This number is
derived by a best guess at a high level of load for a Marshal partition.
I.e., this number is based on:

* 100,000 / 120 seconds = ~833 QPS to the partition
* In standard load, all claims generate 1 Heartbeat per ~30 seconds
* That means 24,990 partitions need to be claimed _per Marshal partition_
  for this threshold to be exceeded
* The Marshal topic can be partitioned heavily (we use 50 at Dropbox)
* Kafka itself only handles ~10,000 partitions per cluster, so exceeding
  this threshold would be pretty spectacular

Given all this, I believe 100,000 offsets to be safe and sane with
plenty of headroom.

The worst case behavior if this number is insufficient is that we will
claim a partition someone else owns. In that case, the other consumer
will detect that someone conflicted and it will stop consuming. This
will lead to at worse a little more double-consumption and partition
churn, which should be caught with monitoring.