### PR TITLE
Improve locking

### DIFF
--- a/marshal/rationalizer.go
+++ b/marshal/rationalizer.go
@@ -126,7 +126,7 @@ func (w *Marshaler) kafkaConsumerChannel(partID int) <-chan message {
 
 // updateClaim is called whenever we need to adjust a claim structure.
 func (w *Marshaler) updateClaim(msg *msgHeartbeat) {
-	topic := w.getTopicState(msg.GroupID, msg.Topic, msg.PartID)
+	topic := w.getPartitionState(msg.GroupID, msg.Topic, msg.PartID)
 
 	topic.lock.Lock()
 	defer topic.lock.Unlock()
@@ -142,7 +142,7 @@ func (w *Marshaler) updateClaim(msg *msgHeartbeat) {
 
 // releaseClaim is called whenever someone has released their claim on a partition.
 func (w *Marshaler) releaseClaim(msg *msgReleasingPartition) {
-	topic := w.getTopicState(msg.GroupID, msg.Topic, msg.PartID)
+	topic := w.getPartitionState(msg.GroupID, msg.Topic, msg.PartID)
 
 	topic.lock.Lock()
 	defer topic.lock.Unlock()
@@ -162,7 +162,7 @@ func (w *Marshaler) releaseClaim(msg *msgReleasingPartition) {
 
 // handleClaim is called whenever we see a ClaimPartition message.
 func (w *Marshaler) handleClaim(msg *msgClaimingPartition) {
-	topic := w.getTopicState(msg.GroupID, msg.Topic, msg.PartID)
+	topic := w.getPartitionState(msg.GroupID, msg.Topic, msg.PartID)
 
 	topic.lock.Lock()
 	defer topic.lock.Unlock()

--- a/marshal/rationalizer_test.go
+++ b/marshal/rationalizer_test.go
@@ -32,7 +32,7 @@ func (s *RationalizerSuite) SetUpTest(c *C) {
 	// Build our return channel and insert it (simulating what the marshal does for
 	// actually trying to claim)
 	s.ret = make(chan bool, 1)
-	topic := s.m.getTopicState(s.m.groupID, "test1", 0)
+	topic := s.m.getPartitionState(s.m.groupID, "test1", 0)
 	topic.lock.Lock()
 	topic.partitions[0].pendingClaims = append(topic.partitions[0].pendingClaims, s.ret)
 	topic.lock.Unlock()

--- a/marshal/world_test.go
+++ b/marshal/world_test.go
@@ -1,0 +1,77 @@
+package marshal
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/optiopay/kafka/kafkatest"
+)
+
+var _ = Suite(&WorldSuite{})
+
+type WorldSuite struct {
+	s *kafkatest.Server
+	m *Marshaler
+}
+
+func (s *WorldSuite) SetUpTest(c *C) {
+	s.s = StartServer()
+
+	var err error
+	s.m, err = NewMarshaler("cl", "gr", []string{s.s.Addr()})
+	if err != nil {
+		c.Errorf("New Marshaler failed: %s", err)
+	}
+}
+
+func (s *WorldSuite) TearDownTest(c *C) {
+	s.m.Terminate()
+	s.s.Close()
+}
+
+func (s *WorldSuite) TestGetTopicState(c *C) {
+	// Always works
+	c.Assert(s.m.getPartitionState("gr", "test2", 0), NotNil)
+
+	// Should error (not claimed)
+	topic, err := s.m.getClaimedPartitionState("gr", "test2", 0)
+	c.Assert(topic, IsNil)
+	c.Assert(err, NotNil)
+
+	// Now claim this partition
+	c.Assert(s.m.ClaimPartition("test2", 0), Equals, true)
+	c.Assert(s.m.waitForRsteps(1), Equals, 1)
+
+	// getClaimed should now work for our group
+	topic, err = s.m.getClaimedPartitionState("gr", "test2", 0)
+	c.Assert(topic, NotNil)
+	c.Assert(err, IsNil)
+
+	// And fail here
+	topic, err = s.m.getClaimedPartitionState("gr2", "test2", 0)
+	c.Assert(topic, IsNil)
+	c.Assert(err, NotNil)
+
+	// And fail here (our group, diff partition)
+	topic, err = s.m.getClaimedPartitionState("gr", "test2", 1)
+	c.Assert(topic, IsNil)
+	c.Assert(err, NotNil)
+
+	// Release partition now
+	c.Assert(s.m.ReleasePartition("test2", 0, 0), IsNil)
+	c.Assert(s.m.waitForRsteps(2), Equals, 2)
+
+	// getClaimed should now fail again for our group
+	topic, err = s.m.getClaimedPartitionState("gr", "test2", 0)
+	c.Assert(topic, IsNil)
+	c.Assert(err, NotNil)
+
+	// And fail here
+	topic, err = s.m.getClaimedPartitionState("gr2", "test2", 0)
+	c.Assert(topic, IsNil)
+	c.Assert(err, NotNil)
+
+	// And fail here (our group, diff partition)
+	topic, err = s.m.getClaimedPartitionState("gr", "test2", 1)
+	c.Assert(topic, IsNil)
+	c.Assert(err, NotNil)
+}


### PR DESCRIPTION
We were over-broad in our locking. This puts the locks around the
accesses to the data structure so we protect them, but then releases
them before we talk to Kafka. This improves heartbeat throughput.

We also remove all locking from CommitOffsets since it just sends a
message to Kafka and doesn't use any local data.