### PR TITLE
Lockless message pump channel operations

### DIFF
--- a/marshal/claim.go
+++ b/marshal/claim.go
@@ -297,6 +297,8 @@ func (c *claim) teardown(releasePartition bool) bool {
 // messagePump continuously pulls message from Kafka for this partition and makes them
 // available for consumption.
 func (c *claim) messagePump() {
+	defer func() { c.pumpStopped <- true }()
+
 	// This method MUST NOT make changes to the claim structure. Since we might
 	// be running while someone else has the lock, and we can't get it ourselves, we are
 	// forbidden to touch anything other than the consumer and the message channel.
@@ -337,7 +339,6 @@ func (c *claim) messagePump() {
 		c.messages <- msg
 	}
 	log.Debugf("[%s:%d] no longer claimed, pump exiting", c.topic, c.partID)
-	c.pumpStopped <- true
 }
 
 // heartbeat is the internal "send a heartbeat" function. Calling this will immediately


### PR DESCRIPTION
Two main changes in this diff:

1. Lose messageLock. This is important because sending to the channel can block, either during long holds of the consumer lock or because the buffer fills up (which we should be able to recover cleanly from)

2. Fix some possible race conditions between acquiring a newClaim and Terminate, make sure we never have unregistered (not in Consumer.claims) message pumps running. 