### PR TITLE
Batch declaim

### DIFF
--- a/marshal/claim_test.go
+++ b/marshal/claim_test.go
@@ -27,6 +27,7 @@ func (s *ClaimSuite) SetUpTest(c *C) {
 	s.m, err = NewMarshaler("cl", "gr", []string{s.s.Addr()})
 	c.Assert(err, IsNil)
 	s.cl = newClaim("test16", 0, s.m, s.ch, NewConsumerOptions())
+	s.cl.startMessagePump()
 }
 
 func (s *ClaimSuite) TearDownTest(c *C) {

--- a/marshal/consumer.go
+++ b/marshal/consumer.go
@@ -113,7 +113,9 @@ func (m *Marshaler) NewConsumer(topicName string, options ConsumerOptions) (*Con
 				// and our heartbeat will happen shortly from the automatic health
 				// check which fires up immediately on newClaim.
 				log.Infof("[%s:%d] attempting to fast-reclaim", c.topic, partID)
-				c.claims[partID] = newClaim(c.topic, partID, c.marshal, c.messages, options)
+				newClaim := newClaim(c.topic, partID, c.marshal, c.messages, options)
+				newClaim.startMessagePump()
+				c.claims[partID] = newClaim
 			}
 		}
 	}
@@ -181,6 +183,7 @@ func (c *Consumer) tryClaimPartition(partID int) bool {
 	}
 
 	// Save the claim, this makes it available for message consumption and status.
+	newClaim.startMessagePump()
 	c.claims[partID] = newClaim
 	return true
 }
@@ -291,21 +294,34 @@ func (c *Consumer) Terminated() bool {
 }
 
 // Terminate instructs the consumer to commit its offsets and possibly release its partitions.
-// This will allow other consumers to begin consuming.
+// This will allow other consumers to begin consuming. c.claimed is first cleared for all claims
+// before we start terminating each one. This avoids locking
 // (If you do not call this method before exiting, things will still work, but more slowly.)
 func (c *Consumer) Terminate(release bool) bool {
 	if !atomic.CompareAndSwapInt32(c.alive, 1, 0) {
 		return false
 	}
 
-	c.lock.Lock()
-	defer c.lock.Unlock()
+	c.lock.RLock()
+	defer c.lock.RUnlock()
 
-	for _, claim := range c.claims {
-		if claim != nil {
-			if release {
+	switch release {
+	case true:
+		for _, claim := range c.claims {
+			if claim != nil {
 				claim.Release()
-			} else {
+			}
+		}
+	default:
+		log.Debugf("De-claiming all claims")
+		for _, claim := range c.claims {
+			if claim != nil {
+				claim.Declaim()
+			}
+		}
+		log.Debugf("Tearing claims down")
+		for _, claim := range c.claims {
+			if claim != nil {
 				claim.Terminate()
 			}
 		}


### PR DESCRIPTION
- Batch declaim claim objects before actually trying to terminate them. 
- Separate message pump start from newClaim setup to fix a race with terminate.