### PR TITLE
Move updateOffsets into heartbeat

### DIFF
--- a/marshal/claim_test.go
+++ b/marshal/claim_test.go
@@ -47,9 +47,9 @@ func (s *ClaimSuite) Produce(topicName string, partID int, msgs ...string) int64
 
 func (s *ClaimSuite) TestOffsetUpdates(c *C) {
 	// Test that the updateOffsets function works and updates offsets from Kafka
-	c.Assert(s.cl.updateOffsets(0), IsNil)
+	c.Assert(s.cl.updateOffsets(), IsNil)
 	c.Assert(s.Produce("test16", 0, "m1", "m2", "m3"), Equals, int64(2))
-	c.Assert(s.cl.updateOffsets(1), IsNil)
+	c.Assert(s.cl.updateOffsets(), IsNil)
 	c.Assert(s.cl.offsets.Latest, Equals, int64(3))
 }
 
@@ -67,7 +67,7 @@ func (s *ClaimSuite) TestCommit(c *C) {
 	// Test the commit message flow, ensuring that our offset only gets updated when
 	// we have properly committed messages
 	c.Assert(s.Produce("test16", 0, "m1", "m2", "m3", "m4", "m5", "m6"), Equals, int64(5))
-	c.Assert(s.cl.updateOffsets(0), IsNil)
+	c.Assert(s.cl.updateOffsets(), IsNil)
 	c.Assert(s.cl.heartbeat(), Equals, true)
 	c.Assert(s.cl.offsets.Current, Equals, int64(0))
 	c.Assert(s.cl.offsets.Earliest, Equals, int64(0))
@@ -132,7 +132,7 @@ func (s *ClaimSuite) TestOrderedConsume(c *C) {
 	// Turn on ordered consumption
 	s.cl.options.StrictOrdering = true
 	c.Assert(s.Produce("test16", 0, "m1", "m2", "m3", "m4", "m5", "m6"), Equals, int64(5))
-	c.Assert(s.cl.updateOffsets(0), IsNil)
+	c.Assert(s.cl.updateOffsets(), IsNil)
 	c.Assert(s.cl.heartbeat(), Equals, true)
 	c.Assert(s.cl.offsets.Current, Equals, int64(0))
 	c.Assert(s.cl.offsets.Earliest, Equals, int64(0))
@@ -227,7 +227,7 @@ func (s *ClaimSuite) TestCommitOutstanding(c *C) {
 	// Test that calling CommitOffsets should commit offsets for outstanding messages and
 	// updates claim tracking
 	c.Assert(s.Produce("test16", 0, "m1", "m2", "m3", "m4", "m5", "m6"), Equals, int64(5))
-	c.Assert(s.cl.updateOffsets(0), IsNil)
+	c.Assert(s.cl.updateOffsets(), IsNil)
 	c.Assert(s.cl.offsets.Current, Equals, int64(0))
 	c.Assert(s.cl.offsets.Earliest, Equals, int64(0))
 	c.Assert(s.cl.offsets.Latest, Equals, int64(6))

--- a/marshal/consumer_test.go
+++ b/marshal/consumer_test.go
@@ -223,7 +223,7 @@ func (s *ConsumerSuite) TestUnhealthyPartition(c *C) {
 	s.Produce("test16", 0, "m1")
 	c.Assert(s.cn.consumeOne().Value, DeepEquals, []byte("m1"))
 	s.cn.claims[0].heartbeat()
-	c.Assert(cl.updateOffsets(0), IsNil)
+	c.Assert(cl.updateOffsets(), IsNil)
 	c.Assert(cl.healthCheck(), Equals, true)
 	c.Assert(cl.cyclesBehind, Equals, 0)
 
@@ -234,7 +234,7 @@ func (s *ConsumerSuite) TestUnhealthyPartition(c *C) {
 	c.Assert(s.cn.consumeOne().Value, DeepEquals, []byte("m3"))
 	c.Assert(s.cn.consumeOne().Value, DeepEquals, []byte("m4"))
 	s.cn.claims[0].heartbeat()
-	c.Assert(cl.updateOffsets(1), IsNil)
+	c.Assert(cl.updateOffsets(), IsNil)
 	c.Assert(cl.healthCheck(), Equals, true)
 	c.Assert(cl.cyclesBehind, Equals, 1)
 
@@ -243,19 +243,19 @@ func (s *ConsumerSuite) TestUnhealthyPartition(c *C) {
 	c.Assert(s.cn.consumeOne().Value, DeepEquals, []byte("m5"))
 	c.Assert(s.cn.consumeOne().Value, DeepEquals, []byte("m6"))
 	s.cn.claims[0].heartbeat()
-	c.Assert(cl.updateOffsets(2), IsNil)
+	c.Assert(cl.updateOffsets(), IsNil)
 	c.Assert(cl.healthCheck(), Equals, true)
 	c.Assert(cl.ConsumerVelocity() == cl.PartitionVelocity(), Equals, true)
 	c.Assert(cl.cyclesBehind, Equals, 0)
 
 	// Produce again, falls behind slightly
 	s.Produce("test16", 0, "m7")
-	c.Assert(cl.updateOffsets(3), IsNil)
+	c.Assert(cl.updateOffsets(), IsNil)
 	c.Assert(cl.healthCheck(), Equals, true)
 	c.Assert(cl.cyclesBehind, Equals, 1)
 
 	// Still behind
-	c.Assert(cl.updateOffsets(4), IsNil)
+	c.Assert(cl.updateOffsets(), IsNil)
 	c.Assert(cl.healthCheck(), Equals, true)
 	c.Assert(cl.cyclesBehind, Equals, 2)
 
@@ -263,7 +263,7 @@ func (s *ConsumerSuite) TestUnhealthyPartition(c *C) {
 	// pass as healthy again
 	c.Assert(s.cn.consumeOne().Value, DeepEquals, []byte("m7"))
 	s.cn.claims[0].heartbeat()
-	c.Assert(cl.updateOffsets(5), IsNil)
+	c.Assert(cl.updateOffsets(), IsNil)
 	c.Assert(cl.healthCheck(), Equals, true)
 	c.Assert(cl.cyclesBehind, Equals, 0)
 }


### PR DESCRIPTION
Current offset is calculated at different times than Earliest and Latest.  c.offsets.Current is updated in the heartbeat--->updateCurrentOffsets flow, while Earliest and Latest are updated in the updateOffsetsLoop--->updateOffsets flow. Both of these run on separate schedules, healthCheck may not be accurate. 

This patch moves updateOffsets into heartbeat, so the velocity arrays are updated right after we calculate  the current offset. 