### PR TITLE
Add support for multi-topic claim and limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ func main() {
     defer marshaler.Terminate()
 
     consumer, _ := marshaler.NewConsumer(
-        "some-topic", marshal.NewConsumerOptions())
+        []string{"some-topic"}, marshal.NewConsumerOptions())
     defer consumer.Terminate()
 
     msgChan := consumer.ConsumeChannel()

--- a/example/main.go
+++ b/example/main.go
@@ -33,7 +33,7 @@ func main() {
 	options := marshal.NewConsumerOptions()
 	options.GreedyClaims = true
 
-	consumer, err := marshaler.NewConsumer("some-topic", options)
+	consumer, err := marshaler.NewConsumer([]string{"some-topic"}, options)
 	if err != nil {
 		log.Fatalf("Failed to construct consumer: %s", err)
 	}

--- a/marshal/consumer.go
+++ b/marshal/consumer.go
@@ -49,15 +49,14 @@ type ConsumerOptions struct {
 	StrictOrdering bool
 
 	// The maximum number of claims this Consumer is allowed to hold simultaneously.
-	// This limits the number of partitions claimed. Set to 0 (default) to allow
-	// an unlimited number of claims.
+	// This limits the number of partitions even in the case of multiple topics.
+	// Set to 0 (default) to allow an unlimited number of claims.ß
 	//
 	// Using this option will leave some partitions/topics completely unclaimed
 	// if the number of Consumers in this GroupID falls below the number of
 	// partitions/topics that exist.
 	//
-	// Note this limit does not apply to claims made via FastReclaim. Nor does it
-	// make sense if ClaimEntireTopic is set -- it is an error to use both options.
+	// Note this limit does not apply to claims made via FastReclaim.
 	MaximumClaims int
 }
 
@@ -68,8 +67,8 @@ type ConsumerOptions struct {
 type Consumer struct {
 	alive      *int32
 	marshal    *Marshaler
-	topic      string
-	partitions int
+	topics     []string
+	partitions map[string]int
 	rand       *rand.Rand
 	options    ConsumerOptions
 	messages   chan *proto.Message
@@ -77,43 +76,56 @@ type Consumer struct {
 	// claims maps partition IDs to claim structures. The lock protects read/write
 	// access to this map.
 	lock   sync.RWMutex
-	claims map[int]*claim
+	claims map[string]map[int]*claim
 }
 
 // NewConsumer instantiates a consumer object for a given topic. You must create a
 // separate consumer for every individual topic that you want to consume from. Please
 // see the documentation on ConsumerBehavior.
-func (m *Marshaler) NewConsumer(topicName string, options ConsumerOptions) (*Consumer, error) {
-	// Ensure the user hasn't set a claim limit and put us into topic mode
-	if options.ClaimEntireTopic && options.MaximumClaims != 0 {
-		return nil, errors.New("ClaimEntireTopic and MaximumClaims are incompatible options")
+func (m *Marshaler) NewConsumer(topicNames []string, options ConsumerOptions) (*Consumer, error) {
+	if len(topicNames) > 1 && !options.ClaimEntireTopic {
+		return nil, errors.New("ClaimEntireTopic must be set for more than one topic")
+	} else if len(topicNames) == 0 {
+		return nil, errors.New("length of topicNames must be postive")
+	}
+
+	partitions := make(map[string]int)
+
+	for _, topic := range topicNames {
+		partitions[topic] = m.Partitions(topic)
 	}
 
 	// Construct base structure
 	c := &Consumer{
 		alive:      new(int32),
 		marshal:    m,
-		topic:      topicName,
-		partitions: m.Partitions(topicName),
+		topics:     topicNames,
+		partitions: partitions,
 		options:    options,
 		messages:   make(chan *proto.Message, 10000),
 		rand:       rand.New(rand.NewSource(time.Now().UnixNano())),
-		claims:     make(map[int]*claim),
+		claims:     make(map[string]map[int]*claim),
 	}
 	atomic.StoreInt32(c.alive, 1)
 
-	// Fast-reclaim: iterate over existing claims in this topic and see if
+	// Fast-reclaim: iterate over existing claims in the given topics and see if
 	// any of them look to be ours. Do this before the claim manager kicks off.
 	if c.options.FastReclaim {
-		for partID := 0; partID < c.partitions; partID++ {
-			claim := c.marshal.GetPartitionClaim(c.topic, partID)
-			if claim.ClientID == c.marshal.ClientID() &&
-				claim.GroupID == c.marshal.GroupID() {
-				// This looks to be ours, let's do it. This is basically the fast path,
-				// and our heartbeat will happen shortly from the automatic health
-				// check which fires up immediately on newClaim.
-				log.Infof("[%s:%d] attempting to fast-reclaim", c.topic, partID)
-				c.claims[partID] = newClaim(c.topic, partID, c.marshal, c.messages, options)
+		for topic, partitionCount := range c.partitions {
+			for partID := 0; partID < partitionCount; partID++ {
+				cl := c.marshal.GetPartitionClaim(topic, partID)
+				if cl.ClientID == c.marshal.ClientID() &&
+					cl.GroupID == c.marshal.GroupID() {
+					// This looks to be ours, let's do it. This is basically the fast path,
+					// and our heartbeat will happen shortly from the automatic health
+					// check which fires up immediately on newClaim.
+					log.Infof("[%s:%d] attempting to fast-reclaim", topic, partID)
+					if _, ok := c.claims[topic]; !ok {
+						c.claims[topic] = make(map[int]*claim)
+					}
+					c.claims[topic][partID] = newClaim(
+						topic, partID, c.marshal, c.messages, options)
+				}
 			}
 		}
 	}
@@ -132,26 +144,51 @@ func NewConsumerOptions() ConsumerOptions {
 	}
 }
 
+func (c *Consumer) defaultTopic() string {
+	if len(c.partitions) > 1 {
+		log.Fatalf("attempted to claim partitions for more than one topic")
+	}
+
+	for topic, _ := range c.partitions {
+		return topic
+	}
+
+	log.Fatalf("couldn't find default topic!")
+	return ""
+}
+
+func (c *Consumer) defaultTopicPartitions() int {
+	if len(c.partitions) > 1 {
+		log.Fatalf("attempted to claim partitions for more than one topic")
+	}
+
+	for _, partitions := range c.partitions {
+		return partitions
+	}
+
+	log.Fatalf("couldn't find default topic!")
+	return 0
+}
+
 // tryClaimPartition attempts to claim a partition and make it available in the consumption
 // flow. If this is called a second time on a partition we already own, it will return
 // false. Returns true only if the partition was never claimed and we succeeded in
 // claiming it.
-func (c *Consumer) tryClaimPartition(partID int) bool {
-	// This is a partition claim function, only check the limit if we're in partition
-	// claim mode.
-	if !c.options.ClaimEntireTopic && c.isClaimLimitReached() {
+func (c *Consumer) tryClaimPartition(topic string, partID int) bool {
+
+	if c.isClaimLimitReached() {
 		return false
 	}
 
 	// Partition unclaimed by us, see if it's claimed by anybody
-	currentClaim := c.marshal.GetPartitionClaim(c.topic, partID)
+	currentClaim := c.marshal.GetPartitionClaim(topic, partID)
 	if currentClaim.LastHeartbeat > 0 {
 		return false
 	}
 
 	// Set up internal claim structure we'll track things in, this can block for a while
 	// as it talks to Kafka and waits for rationalizers.
-	newClaim := newClaim(c.topic, partID, c.marshal, c.messages, c.options)
+	newClaim := newClaim(topic, partID, c.marshal, c.messages, c.options)
 	if newClaim == nil {
 		return false
 	}
@@ -173,15 +210,22 @@ func (c *Consumer) tryClaimPartition(partID int) bool {
 	// Ensure we don't have another valid claim in this slot. This shouldn't happen and if
 	// it does we treat it as fatal. If this fires, it indicates with high likelihood there
 	// is a bug in the Marshal state machine somewhere.
-	oldClaim, ok := c.claims[partID]
-	if ok && oldClaim != nil {
-		if oldClaim.Claimed() {
-			log.Fatalf("Internal double-claim for %s:%d.", c.topic, partID)
+	topicClaims, ok := c.claims[topic]
+	if ok {
+		oldClaim, ok := topicClaims[partID]
+		if ok && oldClaim != nil {
+			if oldClaim.Claimed() {
+				log.Fatalf("Internal double-claim for %s:%d.", topic, partID)
+			}
 		}
 	}
 
+	if _, ok := c.claims[topic]; !ok {
+		c.claims[topic] = make(map[int]*claim)
+	}
+
 	// Save the claim, this makes it available for message consumption and status.
-	c.claims[partID] = newClaim
+	c.claims[topic][partID] = newClaim
 	return true
 }
 
@@ -189,10 +233,15 @@ func (c *Consumer) tryClaimPartition(partID int) bool {
 // set on aggressive, this will try to claim ALL partitions that are free. Balanced mode
 // will claim a single partition.
 func (c *Consumer) claimPartitions() {
-	if c.partitions <= 0 {
-		return
+	if len(c.partitions) > 1 {
+		log.Fatalf("attempted to claim partitions for more than a single topic")
 	}
 
+	topic := c.defaultTopic()
+	partitions := c.defaultTopicPartitions()
+	if partitions <= 0 {
+		return
+	}
 	// Don't bother trying to make claims if we are at our claim limit.
 	// This is just an optimization, because we aren't holding the lock here
 	// this check is repeated inside tryClaimPartition.
@@ -200,12 +249,12 @@ func (c *Consumer) claimPartitions() {
 		return
 	}
 
-	offset := rand.Intn(c.partitions)
-	for i := 0; i < c.partitions; i++ {
-		partID := (i + offset) % c.partitions
+	offset := rand.Intn(partitions)
+	for i := 0; i < partitions; i++ {
+		partID := (i + offset) % partitions
 
 		// Get the most recent claim for this partition
-		lastClaim := c.marshal.GetLastPartitionClaim(c.topic, partID)
+		lastClaim := c.marshal.GetLastPartitionClaim(topic, partID)
 		if lastClaim.isClaimed(time.Now().Unix()) {
 			continue
 		}
@@ -219,7 +268,7 @@ func (c *Consumer) claimPartitions() {
 		}
 
 		// Unclaimed, so attempt to claim it
-		if !c.tryClaimPartition(partID) {
+		if !c.tryClaimPartition(topic, partID) {
 			continue
 		}
 
@@ -233,37 +282,40 @@ func (c *Consumer) claimPartitions() {
 // claimTopic attempts to claim the entire topic if we're in that mode. We use partition 0
 // as the key, anybody who has that partition has claimed the entire topic. This requires all
 // consumers to use this mode.
-func (c *Consumer) claimTopic() {
-	if c.partitions <= 0 {
-		return
+func (c *Consumer) claimTopics() {
+	for topic, partitions := range c.partitions {
+		if partitions <= 0 {
+			continue
+		}
+
+		// We use partition 0 as our "key". Whoever claims partition 0 is considered the owner of
+		// the topic. See if partition 0 is claimed or not.
+		lastClaim := c.marshal.GetLastPartitionClaim(topic, 0)
+		if lastClaim.isClaimed(time.Now().Unix()) {
+			// If it's not claimed by us, return.
+			if lastClaim.GroupID != c.marshal.groupID ||
+				lastClaim.ClientID != c.marshal.clientID {
+				continue
+			}
+		} else {
+			// Unclaimed, so attempt to claim partition 0. This is how we key topic claims.
+			log.Infof("[%s] attempting to claim topic (key partition 0)\n", topic)
+			if !c.tryClaimPartition(topic, 0) {
+				continue
+			}
+			log.Infof("[%s] claimed topic (key partition 0) successfully\n", topic)
+		}
+
+		// We either just claimed or we have already owned the 0th partition. Let's iterate
+		// through all partitions and attempt to claim any that we don't own yet.
+		for partID := 1; partID < partitions; partID++ {
+			if !c.marshal.IsClaimed(topic, partID) {
+				log.Infof("[%s:%d] claiming partition (topic claim mode)\n", topic, partID)
+				c.tryClaimPartition(topic, partID)
+			}
+		}
 	}
 
-	// We use partition 0 as our "key". Whoever claims partition 0 is considered the owner of
-	// the topic. See if partition 0 is claimed or not.
-	lastClaim := c.marshal.GetLastPartitionClaim(c.topic, 0)
-	if lastClaim.isClaimed(time.Now().Unix()) {
-		// If it's not claimed by us, return.
-		if lastClaim.GroupID != c.marshal.groupID ||
-			lastClaim.ClientID != c.marshal.clientID {
-			return
-		}
-	} else {
-		// Unclaimed, so attempt to claim partition 0. This is how we key topic claims.
-		log.Infof("[%s] attempting to claim topic (key partition 0)", c.topic)
-		if !c.tryClaimPartition(0) {
-			return
-		}
-		log.Infof("[%s] claimed topic (key partition 0) successfully", c.topic)
-	}
-
-	// We either just claimed or we have already owned the 0th partition. Let's iterate
-	// through all partitions and attempt to claim any that we don't own yet.
-	for partID := 1; partID < c.partitions; partID++ {
-		if !c.marshal.IsClaimed(c.topic, partID) {
-			log.Infof("[%s:%d] claiming partition (topic claim mode)", c.topic, partID)
-			c.tryClaimPartition(partID)
-		}
-	}
 }
 
 // manageClaims is our internal state machine that handles partitions and claiming new
@@ -273,7 +325,7 @@ func (c *Consumer) manageClaims() {
 		// Attempt to claim more partitions, this always runs and will keep running until all
 		// partitions in the topic are claimed (by somebody).
 		if c.options.ClaimEntireTopic {
-			c.claimTopic()
+			c.claimTopics()
 		} else {
 			c.claimPartitions()
 		}
@@ -298,15 +350,17 @@ func (c *Consumer) Terminate(release bool) bool {
 		return false
 	}
 
-	c.lock.Lock()
-	defer c.lock.Unlock()
+	c.lock.RLock()
+	defer c.lock.RUnlock()
 
-	for _, claim := range c.claims {
-		if claim != nil {
-			if release {
-				claim.Release()
-			} else {
-				claim.Terminate()
+	for _, topicClaims := range c.claims {
+		for _, claim := range topicClaims {
+			if claim != nil {
+				if release {
+					claim.Release()
+				} else {
+					claim.Terminate()
+				}
 			}
 		}
 	}
@@ -325,9 +379,11 @@ func (c *Consumer) GetCurrentLag() int64 {
 	defer c.lock.RUnlock()
 
 	var lag int64
-	for _, cl := range c.claims {
-		if cl.Claimed() {
-			lag += cl.GetCurrentLag()
+	for _, topicClaims := range c.claims {
+		for _, cl := range topicClaims {
+			if cl.Claimed() {
+				lag += cl.GetCurrentLag()
+			}
 		}
 	}
 	return lag
@@ -345,9 +401,11 @@ func (c *Consumer) getNumActiveClaims() (ct int) {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 
-	for _, cl := range c.claims {
-		if cl.Claimed() {
-			ct++
+	for _, topicClaims := range c.claims {
+		for _, cl := range topicClaims {
+			if cl.Claimed() {
+				ct++
+			}
 		}
 	}
 	return
@@ -381,7 +439,7 @@ func (c *Consumer) Commit(msg *proto.Message) error {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 
-	claim, ok := c.claims[int(msg.Partition)]
+	claim, ok := c.claims[msg.Topic][int(msg.Partition)]
 	if !ok {
 		return errors.New("Message not committed (partition claim expired).")
 	}

--- a/marshal/consumer_test.go
+++ b/marshal/consumer_test.go
@@ -8,6 +8,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"fmt"
 	"github.com/optiopay/kafka/kafkatest"
 	"github.com/optiopay/kafka/proto"
 )
@@ -22,16 +23,20 @@ type ConsumerSuite struct {
 	cn *Consumer
 }
 
-func (s *ConsumerSuite) NewTestConsumer(m *Marshaler, topic string) *Consumer {
+func (s *ConsumerSuite) NewTestConsumer(m *Marshaler, topics []string) *Consumer {
 	cn := &Consumer{
 		alive:      new(int32),
 		marshal:    m,
-		topic:      topic,
-		partitions: m.Partitions(topic),
+		topics:     topics,
 		options:    NewConsumerOptions(),
+		partitions: make(map[string]int),
 		rand:       rand.New(rand.NewSource(time.Now().UnixNano())),
-		claims:     make(map[int]*claim),
+		claims:     make(map[string]map[int]*claim),
 		messages:   make(chan *proto.Message, 1000),
+	}
+
+	for _, topic := range topics {
+		cn.partitions[topic] = m.Partitions(topic)
 	}
 	atomic.StoreInt32(cn.alive, 1)
 	return cn
@@ -47,11 +52,13 @@ func (s *ConsumerSuite) SetUpTest(c *C) {
 	s.m2, err = NewMarshaler("cl2", "gr", []string{s.s.Addr()})
 	c.Assert(err, IsNil)
 
-	s.cn = s.NewTestConsumer(s.m, "test16")
+	s.cn = s.NewTestConsumer(s.m, []string{"test16"})
 }
 
 func (s *ConsumerSuite) TearDownTest(c *C) {
-	s.cn.Terminate(true)
+	if s.cn != nil {
+		s.cn.Terminate(true)
+	}
 	s.m.Terminate()
 	s.s.Close()
 }
@@ -70,7 +77,7 @@ func (s *ConsumerSuite) TestNewConsumer(c *C) {
 	options := NewConsumerOptions()
 	options.GreedyClaims = true
 
-	cn, err := s.m.NewConsumer("test1", options)
+	cn, err := s.m.NewConsumer([]string{"test1"}, options)
 	c.Assert(err, IsNil)
 	defer cn.Terminate(true)
 
@@ -92,25 +99,25 @@ func (s *ConsumerSuite) TestNewConsumer(c *C) {
 func (s *ConsumerSuite) TestTerminateWithRelease(c *C) {
 	// Termination is supposed to release active claims that we have, ensure that
 	// this happens
-	c.Assert(s.cn.tryClaimPartition(0), Equals, true)
+	c.Assert(s.cn.tryClaimPartition(s.cn.defaultTopic(), 0), Equals, true)
 	c.Assert(s.cn.Terminate(true), Equals, true)
 	c.Assert(s.m.waitForRsteps(3), Equals, 3)
-	c.Assert(s.m.GetPartitionClaim(s.cn.topic, 0).LastHeartbeat, Equals, int64(0))
+	c.Assert(s.m.GetPartitionClaim(s.cn.defaultTopic(), 0).LastHeartbeat, Equals, int64(0))
 }
 
 func (s *ConsumerSuite) TestTerminateWithoutRelease(c *C) {
 	// Termination is supposed to commit the active claims without releasing the partition
-	c.Assert(s.cn.tryClaimPartition(0), Equals, true)
+	c.Assert(s.cn.tryClaimPartition(s.cn.defaultTopic(), 0), Equals, true)
 	c.Assert(s.cn.Terminate(false), Equals, true)
 	// Shouldn't release the partition
-	c.Assert(s.m.GetPartitionClaim(s.cn.topic, 0).LastHeartbeat, Not(Equals), int64(0))
+	c.Assert(s.m.GetPartitionClaim(s.cn.defaultTopic(), 0).LastHeartbeat, Not(Equals), int64(0))
 }
 
 func (s *ConsumerSuite) TestMultiClaim(c *C) {
 	// Set up claims on two partitions, we'll put messages in both and then ensure that
 	// we get all of the messages out
-	c.Assert(s.cn.tryClaimPartition(0), Equals, true)
-	c.Assert(s.cn.tryClaimPartition(1), Equals, true)
+	c.Assert(s.cn.tryClaimPartition(s.cn.defaultTopic(), 0), Equals, true)
+	c.Assert(s.cn.tryClaimPartition(s.cn.defaultTopic(), 1), Equals, true)
 	numMessages := 100
 	// Produce numMessages messages to the two partitions
 	for i := 0; i < numMessages; i++ {
@@ -126,36 +133,38 @@ func (s *ConsumerSuite) TestMultiClaim(c *C) {
 }
 
 func (s *ConsumerSuite) TestTopicClaim(c *C) {
+	topic := "test2"
 	// Claim an entire topic
 	options := NewConsumerOptions()
 	options.ClaimEntireTopic = true
-	cn, err := s.m.NewConsumer("test2", options)
+	cn, err := s.m.NewConsumer([]string{topic}, options)
 	c.Assert(err, IsNil)
 	defer cn.Terminate(true)
 
 	// Wait for 4 messages to be processed and ensure we have the entire topic
 	c.Assert(s.m.waitForRsteps(4), Equals, 4)
-	c.Assert(s.m.GetPartitionClaim("test2", 0).LastHeartbeat, Not(Equals), int64(0))
-	c.Assert(s.m.GetPartitionClaim("test2", 1).LastHeartbeat, Not(Equals), int64(0))
+	c.Assert(s.m.GetPartitionClaim(topic, 0).LastHeartbeat, Not(Equals), int64(0))
+	c.Assert(s.m.GetPartitionClaim(topic, 1).LastHeartbeat, Not(Equals), int64(0))
 }
 
 func (s *ConsumerSuite) TestTopicClaimBlocked(c *C) {
+	topic := "test2"
 	// Claim partition 0 with one consumer
-	cnbl := s.NewTestConsumer(s.m, "test2")
-	c.Assert(cnbl.tryClaimPartition(0), Equals, true)
+	cnbl := s.NewTestConsumer(s.m, []string{topic})
+	c.Assert(cnbl.tryClaimPartition(topic, 0), Equals, true)
 	c.Assert(s.m.waitForRsteps(2), Equals, 2)
 	c.Assert(s.m2.waitForRsteps(2), Equals, 2)
 
 	// Claim an entire topic, this creates a real consumer
-	cn := s.NewTestConsumer(s.m2, "test2")
+	cn := s.NewTestConsumer(s.m2, []string{topic})
 	cn.options.ClaimEntireTopic = true
 	defer cn.Terminate(true)
 
 	// Force our consumer to run it's topic claim loop so we know it has run
-	cn.claimTopic()
+	cn.claimTopics()
 
 	// Ensure partition 1 is unclaimed still and that our new consumer has no claims
-	c.Assert(s.m.GetPartitionClaim("test2", 1).LastHeartbeat, Equals, int64(0))
+	c.Assert(s.m.GetPartitionClaim(topic, 1).LastHeartbeat, Equals, int64(0))
 	c.Assert(cnbl.getNumActiveClaims(), Equals, 1)
 	c.Assert(cn.getNumActiveClaims(), Equals, 0)
 
@@ -167,25 +176,26 @@ func (s *ConsumerSuite) TestTopicClaimBlocked(c *C) {
 	c.Assert(cn.getNumActiveClaims(), Equals, 0)
 
 	// Reclaim and assert we get two claims
-	cn.claimTopic()
+	cn.claimTopics()
 	c.Assert(cnbl.getNumActiveClaims(), Equals, 0)
 	c.Assert(cn.getNumActiveClaims(), Equals, 2)
 }
 
 func (s *ConsumerSuite) TestTopicClaimPartial(c *C) {
+	topic := "test2"
 	// Claim partition 1 with one consumer
-	cnbl := s.NewTestConsumer(s.m, "test2")
-	c.Assert(cnbl.tryClaimPartition(1), Equals, true)
+	cnbl := s.NewTestConsumer(s.m, []string{topic})
+	c.Assert(cnbl.tryClaimPartition(topic, 1), Equals, true)
 	c.Assert(s.m.waitForRsteps(2), Equals, 2)
 	c.Assert(s.m2.waitForRsteps(2), Equals, 2)
 
 	// Claim an entire topic, this creates a real consumer
-	cn := s.NewTestConsumer(s.m2, "test2")
+	cn := s.NewTestConsumer(s.m2, []string{topic})
 	cn.options.ClaimEntireTopic = true
 	defer cn.Terminate(true)
 
 	// Force our consumer to run it's topic claim loop so we know it has run
-	cn.claimTopic()
+	cn.claimTopics()
 
 	// Both should have 1 partition -- the topic claim got 0, and the other one still has 1.
 	// This can happen in the case where a consumer has died and partition 0's claim expires
@@ -202,17 +212,48 @@ func (s *ConsumerSuite) TestTopicClaimPartial(c *C) {
 	c.Assert(cn.getNumActiveClaims(), Equals, 1)
 
 	// Now the topic claimant runs again and will see it can claim partition 1 and does
-	cn.claimTopic()
+	cn.claimTopics()
 	c.Assert(s.m.waitForRsteps(7), Equals, 7)
 	c.Assert(s.m2.waitForRsteps(7), Equals, 7)
 	c.Assert(cnbl.getNumActiveClaims(), Equals, 0)
 	c.Assert(cn.getNumActiveClaims(), Equals, 2)
 }
 
+func (s *ConsumerSuite) TestMultiTopicClaim(c *C) {
+	// Claim partition 1 with one consumer
+	topics := []string{"test1", "test2", "test16"}
+	cn := s.NewTestConsumer(s.m, topics)
+	cn.options.ClaimEntireTopic = true
+	defer cn.Terminate(true)
+
+	// Force our consumer to run it's topic claim loop so we know it has run
+	cn.claimTopics()
+
+	// we should have claimed all topic partitions
+	partitions := 0
+	for _, topic := range topics {
+		partitions += s.m.Partitions(topic)
+	}
+	c.Assert(cn.getNumActiveClaims(), Equals, partitions)
+}
+
+func (s *ConsumerSuite) TestMultiTopicClaimWithLimit(c *C) {
+	// Claim partition 1 with one consumer
+	topics := []string{"test1", "test2", "test16"}
+	cn := s.NewTestConsumer(s.m, topics)
+	cn.options.ClaimEntireTopic = true
+	cn.options.MaximumClaims = 7
+	defer cn.Terminate(true)
+
+	// Force our consumer to run it's topic claim loop so we know it has run
+	cn.claimTopics()
+	c.Assert(cn.getNumActiveClaims(), Equals, 7)
+}
+
 func (s *ConsumerSuite) TestUnhealthyPartition(c *C) {
-	c.Assert(s.cn.tryClaimPartition(0), Equals, true)
+	c.Assert(s.cn.tryClaimPartition(s.cn.defaultTopic(), 0), Equals, true)
 	s.cn.lock.RLock()
-	cl := s.cn.claims[0]
+	cl := s.cn.claims[s.cn.defaultTopic()][0]
 	s.cn.lock.RUnlock()
 
 	// We just claimed, nothing should be unhealthy
@@ -222,7 +263,7 @@ func (s *ConsumerSuite) TestUnhealthyPartition(c *C) {
 	// Put in one message and consume it making sure things work, and then update offsets.
 	s.Produce("test16", 0, "m1")
 	c.Assert(s.cn.consumeOne().Value, DeepEquals, []byte("m1"))
-	s.cn.claims[0].heartbeat()
+	s.cn.claims[s.cn.defaultTopic()][0].heartbeat()
 	c.Assert(cl.updateOffsets(0), IsNil)
 	c.Assert(cl.healthCheck(), Equals, true)
 	c.Assert(cl.cyclesBehind, Equals, 0)
@@ -233,7 +274,7 @@ func (s *ConsumerSuite) TestUnhealthyPartition(c *C) {
 	c.Assert(s.cn.consumeOne().Value, DeepEquals, []byte("m2"))
 	c.Assert(s.cn.consumeOne().Value, DeepEquals, []byte("m3"))
 	c.Assert(s.cn.consumeOne().Value, DeepEquals, []byte("m4"))
-	s.cn.claims[0].heartbeat()
+	s.cn.claims[s.cn.defaultTopic()][0].heartbeat()
 	c.Assert(cl.updateOffsets(1), IsNil)
 	c.Assert(cl.healthCheck(), Equals, true)
 	c.Assert(cl.cyclesBehind, Equals, 1)
@@ -242,7 +283,7 @@ func (s *ConsumerSuite) TestUnhealthyPartition(c *C) {
 	// we are caught up and our velocity is equal
 	c.Assert(s.cn.consumeOne().Value, DeepEquals, []byte("m5"))
 	c.Assert(s.cn.consumeOne().Value, DeepEquals, []byte("m6"))
-	s.cn.claims[0].heartbeat()
+	s.cn.claims[s.cn.defaultTopic()][0].heartbeat()
 	c.Assert(cl.updateOffsets(2), IsNil)
 	c.Assert(cl.healthCheck(), Equals, true)
 	c.Assert(cl.ConsumerVelocity() == cl.PartitionVelocity(), Equals, true)
@@ -262,27 +303,27 @@ func (s *ConsumerSuite) TestUnhealthyPartition(c *C) {
 	// Consume the last message, which will fix our velocity and let us
 	// pass as healthy again
 	c.Assert(s.cn.consumeOne().Value, DeepEquals, []byte("m7"))
-	s.cn.claims[0].heartbeat()
+	s.cn.claims[s.cn.defaultTopic()][0].heartbeat()
 	c.Assert(cl.updateOffsets(5), IsNil)
 	c.Assert(cl.healthCheck(), Equals, true)
 	c.Assert(cl.cyclesBehind, Equals, 0)
 }
 
 func (s *ConsumerSuite) TestConsumerHeartbeat(c *C) {
-	c.Assert(s.cn.tryClaimPartition(0), Equals, true)
+	c.Assert(s.cn.tryClaimPartition(s.cn.defaultTopic(), 0), Equals, true)
 	c.Assert(s.m.waitForRsteps(2), Equals, 2)
-
+	cl := s.cn.claims[s.cn.defaultTopic()][0]
 	// Newly claimed partition should have heartbeated
-	c.Assert(s.cn.claims[0].lastHeartbeat, Not(Equals), 0)
+	c.Assert(cl.lastHeartbeat, Not(Equals), 0)
 
 	// Now reset the heartbeat to some other value
-	s.cn.claims[0].lastHeartbeat -= HeartbeatInterval
-	hb := s.cn.claims[0].lastHeartbeat
+	cl.lastHeartbeat -= HeartbeatInterval
+	hb := cl.lastHeartbeat
 
 	// Manual heartbeat, ensure lastHeartbeat is updated
-	s.cn.claims[0].heartbeat()
+	cl.heartbeat()
 	c.Assert(s.m.waitForRsteps(3), Equals, 3)
-	c.Assert(s.cn.claims[0].lastHeartbeat, Not(Equals), hb)
+	c.Assert(cl.lastHeartbeat, Not(Equals), hb)
 }
 
 func (s *ConsumerSuite) TestCommittedOffset(c *C) {
@@ -290,23 +331,24 @@ func (s *ConsumerSuite) TestCommittedOffset(c *C) {
 	// prefer them over the heartbeated values (if they're higher)
 	s.Produce("test16", 0, "m1", "m2", "m3", "m4")
 	c.Assert(s.m.offsets.Commit("test16", 0, 2), IsNil)
-	c.Assert(s.cn.tryClaimPartition(0), Equals, true)
+	c.Assert(s.cn.tryClaimPartition(s.cn.defaultTopic(), 0), Equals, true)
 	c.Assert(s.m.waitForRsteps(2), Equals, 2)
-	c.Assert(s.cn.claims[0].offsets.Current, Equals, int64(2))
+	cl := s.cn.claims[s.cn.defaultTopic()][0]
+	c.Assert(cl.offsets.Current, Equals, int64(2))
 
 	// Since the committed offset was 2, the first consumption should be the third message
 	c.Assert(s.cn.consumeOne().Value, DeepEquals, []byte("m3"))
 
 	// Heartbeat should succeed and update the committed offset
-	c.Assert(s.cn.claims[0].heartbeat(), Equals, true)
+	c.Assert(cl.heartbeat(), Equals, true)
 	c.Assert(s.m.waitForRsteps(3), Equals, 3)
 	offset, _, err := s.m.offsets.Offset("test16", 0)
 	c.Assert(err, IsNil)
 	c.Assert(offset, Equals, int64(3))
-	c.Assert(s.cn.claims[0].Release(), Equals, true)
+	c.Assert(cl.Release(), Equals, true)
 	c.Assert(s.m.waitForRsteps(4), Equals, 4)
-	c.Assert(s.cn.claims[0].Claimed(), Equals, false)
-	s.cn.claims[0] = nil
+	c.Assert(cl.Claimed(), Equals, false)
+	s.cn.claims[s.cn.defaultTopic()][0] = nil
 
 	// Now let's "downcommit" the offset back to an earlier value, and then re-claim the
 	// partition to verify that it sets the offset to the heartbeated value rather than
@@ -315,9 +357,9 @@ func (s *ConsumerSuite) TestCommittedOffset(c *C) {
 	offset, _, err = s.m.offsets.Offset("test16", 0)
 	c.Assert(err, IsNil)
 	c.Assert(offset, Equals, int64(2))
-	c.Assert(s.cn.tryClaimPartition(0), Equals, true)
+	c.Assert(s.cn.tryClaimPartition(s.cn.defaultTopic(), 0), Equals, true)
 	c.Assert(s.m.waitForRsteps(6), Equals, 6)
-	c.Assert(s.cn.claims[0].offsets.Current, Equals, int64(3))
+	c.Assert(s.cn.claims[s.cn.defaultTopic()][0].offsets.Current, Equals, int64(3))
 }
 
 func (s *ConsumerSuite) TestStrictOrdering(c *C) {
@@ -325,8 +367,8 @@ func (s *ConsumerSuite) TestStrictOrdering(c *C) {
 	s.cn.options.StrictOrdering = true
 	s.Produce("test16", 0, "m1", "m2", "m3", "m4")
 	s.Produce("test16", 1, "m1", "m2", "m3", "m4")
-	c.Assert(s.cn.tryClaimPartition(0), Equals, true)
-	c.Assert(s.cn.tryClaimPartition(1), Equals, true)
+	c.Assert(s.cn.tryClaimPartition(s.cn.defaultTopic(), 0), Equals, true)
+	c.Assert(s.cn.tryClaimPartition(s.cn.defaultTopic(), 1), Equals, true)
 	c.Assert(s.m.waitForRsteps(4), Equals, 4)
 
 	msg1 := <-s.cn.messages
@@ -358,9 +400,9 @@ func (s *ConsumerSuite) TestStrictOrdering(c *C) {
 
 func (s *ConsumerSuite) TestTryClaimPartition(c *C) {
 	// Should work
-	c.Assert(s.cn.tryClaimPartition(0), Equals, true)
+	c.Assert(s.cn.tryClaimPartition(s.cn.defaultTopic(), 0), Equals, true)
 	// Should fail (can't claim a second time)
-	c.Assert(s.cn.tryClaimPartition(0), Equals, false)
+	c.Assert(s.cn.tryClaimPartition(s.cn.defaultTopic(), 0), Equals, false)
 }
 
 func (s *ConsumerSuite) TestAggressiveClaim(c *C) {
@@ -382,7 +424,7 @@ func (s *ConsumerSuite) TestFastReclaim(c *C) {
 	// Claim some partitions then create a new consumer with fast reclaim on; this
 	// should "reclaim" the partitions automatically at the offset they were last
 	// reported at
-	cn1, err := s.m.NewConsumer("test2", NewConsumerOptions())
+	cn1, err := s.m.NewConsumer([]string{"test2"}, NewConsumerOptions())
 	c.Assert(err, IsNil)
 	defer cn1.Terminate(true)
 	s.Produce("test2", 0, "m1", "m2", "m3")
@@ -390,13 +432,12 @@ func (s *ConsumerSuite) TestFastReclaim(c *C) {
 	// By default the consumer will claim all partitions so let's wait for that
 	c.Assert(s.m.waitForRsteps(4), Equals, 4)
 	cn1.lock.RLock()
-	cl := cn1.claims[0]
 	cn1.lock.RUnlock()
 
 	// Consume the first two messages from 0, then heartbeat to set the offset to 2
 	c.Assert(cn1.consumeOne().Value, DeepEquals, []byte("m1"))
 	c.Assert(cn1.consumeOne().Value, DeepEquals, []byte("m2"))
-	c.Assert(cl.heartbeat(), Equals, true)
+	c.Assert(cn1.claims["test2"][0].heartbeat(), Equals, true)
 	c.Assert(s.m.waitForRsteps(5), Equals, 5)
 
 	// Now add some messages to the next, but only consume some
@@ -409,16 +450,16 @@ func (s *ConsumerSuite) TestFastReclaim(c *C) {
 	// Now we "reclaim" by creating a new consumer here; this is actually bogus
 	// usage as it would normally lead to stepping on the prior consumer, but it
 	// is useful for this test.
-	cn, err := s.m.NewConsumer("test2", NewConsumerOptions())
+	cn, err := s.m.NewConsumer([]string{"test2"}, NewConsumerOptions())
 	c.Assert(err, IsNil)
 	defer cn.Terminate(true)
 
 	// We expect the two partitions to be reclaimed with a simple heartbeat
 	// and no claim message sent
 	c.Assert(s.m.waitForRsteps(7), Equals, 7)
-	c.Assert(len(cn.claims), Equals, 2)
+	c.Assert(len(cn.claims[cn.defaultTopic()]), Equals, 2)
 	cn.lock.RLock()
-	cl0, cl1 := cn.claims[0], cn.claims[1]
+	cl0, cl1 := cn.claims[cn.defaultTopic()][0], cn.claims[cn.defaultTopic()][1]
 	cn.lock.RUnlock()
 	c.Assert(cl0.offsets.Current, Equals, int64(2))
 	c.Assert(cl1.offsets.Current, Equals, int64(0))


### PR DESCRIPTION
This change includes supporting multiple topics for a single Marshal consumer and honoring MaximumClaims across all topics.
It also fixes a deadlock during consumer terminate