### PR TITLE
Add state printing

### DIFF
--- a/debug/main.go
+++ b/debug/main.go
@@ -12,8 +12,8 @@ import (
 	"flag"
 	"time"
 
+	"github.com/dropbox/marshal/marshal"
 	"github.com/op/go-logging"
-	"github.com/zorkian/marshal/marshal"
 )
 
 var log = logging.MustGetLogger("MarshalDebug")

--- a/example/main.go
+++ b/example/main.go
@@ -5,8 +5,8 @@
 package main
 
 import (
+	"github.com/dropbox/marshal/marshal"
 	"github.com/op/go-logging"
-	"github.com/zorkian/marshal/marshal"
 )
 
 func main() {

--- a/marshal/consumer.go
+++ b/marshal/consumer.go
@@ -185,6 +185,7 @@ func (c *Consumer) tryClaimPartition(partID int) bool {
 			log.Errorf("Internal double-claim for %s:%d.", c.topic, partID)
 			log.Errorf("This is a catastrophic error. We're terminating Marshal.")
 			log.Errorf("No further messages will be available. Please restart.")
+			c.marshal.PrintState()
 			c.marshal.Terminate()
 		}
 	}
@@ -403,4 +404,15 @@ func (c *Consumer) Commit(msg *proto.Message) error {
 		return errors.New("Message not committed (partition claim expired).")
 	}
 	return claim.Commit(msg)
+}
+
+// PrintState outputs the status of the consumer.
+func (c *Consumer) PrintState() {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	log.Infof("  TOPIC: %s [messages queued: %d]", c.topic, len(c.messages))
+	for _, claim := range c.claims {
+		claim.PrintState()
+	}
 }

--- a/marshal/log.go
+++ b/marshal/log.go
@@ -80,6 +80,6 @@ func (l *optiopayLoggerShim) Debug(format string, args ...interface{}) {
 var log *logger
 
 func init() {
-	log = &logger{l: logging.MustGetLogger("PortalMarshal")}
-	logging.SetLevel(logging.INFO, "PortalMarshal")
+	log = &logger{l: logging.MustGetLogger("KafkaMarshal")}
+	logging.SetLevel(logging.INFO, "KafkaMarshal")
 }


### PR DESCRIPTION
This adds a way to print the state of Marshal. This is an extremely
verbose way of seeing exactly what is going on in the state machine.
This also adds an automatic trigger which fires in the double-claim
state.