### PR TITLE
Remove fatals from library

### DIFF
--- a/marshal/consumer.go
+++ b/marshal/consumer.go
@@ -171,27 +171,33 @@ func NewConsumerOptions() ConsumerOptions {
 
 func (c *Consumer) defaultTopic() string {
 	if len(c.partitions) > 1 {
-		log.Fatalf("attempted to claim partitions for more than one topic")
+		log.Errorf("attempted to claim partitions for more than one topic")
+		c.Terminate(false)
+		return ""
 	}
 
 	for topic := range c.partitions {
 		return topic
 	}
 
-	log.Fatalf("couldn't find default topic!")
+	log.Errorf("couldn't find default topic!")
+	c.Terminate(false)
 	return ""
 }
 
 func (c *Consumer) defaultTopicPartitions() int {
 	if len(c.partitions) > 1 {
-		log.Fatalf("attempted to claim partitions for more than one topic")
+		log.Errorf("attempted to claim partitions for more than one topic")
+		c.Terminate(false)
+		return 0
 	}
 
 	for _, partitions := range c.partitions {
 		return partitions
 	}
 
-	log.Fatalf("couldn't find default topic!")
+	log.Errorf("couldn't find default topic!")
+	c.Terminate(false)
 	return 0
 }
 
@@ -246,7 +252,6 @@ func (c *Consumer) tryClaimPartition(topic string, partID int) bool {
 		oldClaim, ok := topicClaims[partID]
 		if ok && oldClaim != nil {
 			if oldClaim.Claimed() {
-				log.Fatalf("Internal double-claim for %s:%d.", topic, partID)
 				log.Errorf("Internal double-claim for %s:%d.", topic, partID)
 				log.Errorf("This is a catastrophic error. We're terminating Marshal.")
 				log.Errorf("No further messages will be available. Please restart.")
@@ -278,7 +283,9 @@ func (c *Consumer) rndIntn(n int) int {
 // will claim a single partition.
 func (c *Consumer) claimPartitions() {
 	if len(c.partitions) > 1 {
-		log.Fatalf("attempted to claim partitions for more than a single topic")
+		log.Errorf("attempted to claim partitions for more than a single topic")
+		c.Terminate(false)
+		return
 	}
 
 	topic := c.defaultTopic()

--- a/marshal/marshal.go
+++ b/marshal/marshal.go
@@ -100,12 +100,11 @@ func NewMarshaler(clientID, groupID string, brokers []string) (*Marshaler, error
 			log.Infof("Refreshing topic metadata.")
 			m.refreshMetadata()
 
-			// See if the number of partitions in the marshal topic went up. If so, this is a
-			// fatal error as it means we lose coordination. In theory a mass die-off of workers
-			// is bad, but so is upsharding the coordination topic without shutting down
-			// everything. At least this limits the damage horizon?
+			// See if the number of partitions in the marshal topic changed. This is bad if
+			// it happens, since it means we can no longer coordinate correctly.
 			if m.Partitions(MarshalTopic) != m.partitions {
-				log.Fatalf("Marshal topic partition count changed. FATAL!")
+				log.Errorf("Marshal topic partition count changed. Terminating!")
+				m.Terminate()
 			}
 		}
 	}()


### PR DESCRIPTION
Calling Fatal in the library means that users can't do graceful handling
of problems. Instead, we should opt for terminating the appropriate
portion of the library (Marshaler or Consumer).