### PR TITLE
Terminating consumer removes itself from marshal's consumer list

### DIFF
--- a/marshal/cluster.go
+++ b/marshal/cluster.go
@@ -284,7 +284,7 @@ func (c *KafkaCluster) Terminate() {
 	// Terminate all Marshalers which will in turn terminate all Consumers and
 	// let everybody know we're all done.
 	for _, marshaler := range c.marshalers {
-		marshaler.Terminate()
+		marshaler.terminateAndCleanup(false)
 	}
 	c.marshalers = nil
 

--- a/marshal/cluster.go
+++ b/marshal/cluster.go
@@ -260,6 +260,19 @@ func (c *KafkaCluster) getTopicPartitions(topicName string) int {
 	return count
 }
 
+// removeMarshal removes a terminated Marshal from a cluster's list.
+func (c *KafkaCluster) removeMarshal(m *Marshaler) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	for i, ml := range m.cluster.marshalers {
+		if ml == m {
+			m.cluster.marshalers = append(m.cluster.marshalers[:i],
+				m.cluster.marshalers[i+1:]...)
+			break
+		}
+	}
+}
+
 // waitForRsteps is used by the test suite to ask the rationalizer to wait until some number
 // of events have been processed. This also returns the current rsteps when it returns.
 func (c *KafkaCluster) waitForRsteps(steps int) int {

--- a/marshal/cluster.go
+++ b/marshal/cluster.go
@@ -264,10 +264,9 @@ func (c *KafkaCluster) getTopicPartitions(topicName string) int {
 func (c *KafkaCluster) removeMarshal(m *Marshaler) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	for i, ml := range m.cluster.marshalers {
+	for i, ml := range c.marshalers {
 		if ml == m {
-			m.cluster.marshalers = append(m.cluster.marshalers[:i],
-				m.cluster.marshalers[i+1:]...)
+			c.marshalers = append(c.marshalers[:i], c.marshalers[i+1:]...)
 			break
 		}
 	}

--- a/marshal/consumer.go
+++ b/marshal/consumer.go
@@ -522,6 +522,16 @@ func (c *Consumer) Terminate(release bool) bool {
 	// updateTopicClaims expects to be called with RLock held
 	c.updateTopicClaims(latestTopicClaims, false)
 	close(c.topicClaimsChan)
+
+	// Remove this consumer from associated marshal.
+	c.marshal.lock.Lock()
+	defer c.marshal.lock.Unlock()
+	for i, cn := range c.marshal.consumers {
+		if cn == c {
+			c.marshal.consumers = append(c.marshal.consumers[:i],
+				c.marshal.consumers[i+1:]...)
+		}
+	}
 	return true
 }
 

--- a/marshal/consumer.go
+++ b/marshal/consumer.go
@@ -521,23 +521,7 @@ func (c *Consumer) terminateAndCleanup(release bool, remove bool) bool {
 	// Optionally remove consumer from its marshal. Doing so is recommended
 	// if the marshal doesn't explicitly remove the consumer.
 	if remove {
-		var wg sync.WaitGroup
-		wg.Add(1)
-		go func() {
-			c.marshal.lock.Lock()
-
-			for i, cn := range c.marshal.consumers {
-				if cn == c {
-					c.marshal.consumers = append(c.marshal.consumers[:i],
-						c.marshal.consumers[i+1:]...)
-					break
-				}
-			}
-			log.Info("Consumer releasing lock")
-			c.marshal.lock.Unlock()
-			wg.Done()
-		}()
-		wg.Wait()
+		c.marshal.removeConsumer(c)
 	}
 
 	// update the claims

--- a/marshal/consumer.go
+++ b/marshal/consumer.go
@@ -482,10 +482,10 @@ func (c *Consumer) Terminated() bool {
 	return atomic.LoadInt32(c.alive) == 0
 }
 
-// Terminate instructs the consumer to commit its offsets and possibly release its partitions.
-// This will allow other consumers to begin consuming.
-// (If you do not call this method before exiting, things will still work, but more slowly.)
-func (c *Consumer) Terminate(release bool) bool {
+// terminateAndCleanup instructs the consumer to commit its offsets,
+// possibly release its partitions, and possibly remove its reference from
+// the associated marshaler. This will allow other consumers to begin consuming.
+func (c *Consumer) terminateAndCleanup(release bool, remove bool) bool {
 	if !atomic.CompareAndSwapInt32(c.alive, 1, 0) {
 		return false
 	}
@@ -518,24 +518,40 @@ func (c *Consumer) Terminate(release bool) bool {
 		}
 	}
 
-	// Remove consumer from its marshal.
-	go func() {
-		c.marshal.lock.Lock()
-		for i, cn := range c.marshal.consumers {
-			if cn == c {
-				c.marshal.consumers = append(c.marshal.consumers[:i],
-					c.marshal.consumers[i+1:]...)
-				break
+	// Optionally remove consumer from its marshal. Doing so is recommended
+	// if the marshal doesn't explicitly remove the consumer.
+	if remove {
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			c.marshal.lock.Lock()
+
+			for i, cn := range c.marshal.consumers {
+				if cn == c {
+					c.marshal.consumers = append(c.marshal.consumers[:i],
+						c.marshal.consumers[i+1:]...)
+					break
+				}
 			}
-		}
-		c.marshal.lock.Unlock()
-	}()
+			log.Info("Consumer releasing lock")
+			c.marshal.lock.Unlock()
+			wg.Done()
+		}()
+		wg.Wait()
+	}
 
 	// update the claims
 	// updateTopicClaims expects to be called with RLock held
 	c.updateTopicClaims(latestTopicClaims, false)
 	close(c.topicClaimsChan)
 	return true
+
+}
+
+// Terminate instructs the consumer to clean up and allow other consumers to begin consuming.
+// (If you do not call this method before exiting, things will still work, but more slowly.)
+func (c *Consumer) Terminate(release bool) bool {
+	return c.terminateAndCleanup(release, true)
 }
 
 // GetCurrentTopicClaims returns the topics that are currently claimed by this

--- a/marshal/consumer_test.go
+++ b/marshal/consumer_test.go
@@ -591,3 +591,11 @@ func (s *ConsumerSuite) TestMaximumGreedyClaims(c *C) {
 	c.Assert(s.cn.isClaimLimitReached(), Equals, true)
 	c.Assert(s.cn.getNumActiveClaims(), Equals, 2)
 }
+
+func (s *ConsumerSuite) TestConsumerRemovesSelfFromMarshal(c *C) {
+	// Test that Consumers remove themselves from the associated Marshal.
+	s.m.addNewConsumer(s.cn)
+	c.Assert(s.m.consumers, DeepEquals, []*Consumer{s.cn})
+	s.cn.Terminate(true)
+	c.Assert(s.cn.marshal.consumers, DeepEquals, []*Consumer{})
+}

--- a/marshal/marshal.go
+++ b/marshal/marshal.go
@@ -138,8 +138,17 @@ func (m *Marshaler) Terminate() {
 	}
 	m.consumers = nil
 
-	// If we own the cluster, terminate it.
+	// If we own the cluster, terminate it, and remove its reference to this marshal.
 	if m.ownsCluster {
+		m.cluster.lock.Lock()
+		for i, marshaler := range m.cluster.marshalers {
+			if m == marshaler {
+				m.cluster.marshalers = append(m.cluster.marshalers[:i],
+					m.cluster.marshalers[i+1:]...)
+				break
+			}
+		}
+		m.cluster.lock.Unlock()
 		m.cluster.Terminate()
 	}
 }

--- a/marshal/marshal.go
+++ b/marshal/marshal.go
@@ -89,10 +89,9 @@ func (m *Marshaler) addNewConsumer(c *Consumer) {
 func (m *Marshaler) removeConsumer(c *Consumer) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	for i, cn := range c.marshal.consumers {
+	for i, cn := range m.consumers {
 		if cn == c {
-			c.marshal.consumers = append(c.marshal.consumers[:i],
-				c.marshal.consumers[i+1:]...)
+			m.consumers = append(m.consumers[:i], m.consumers[i+1:]...)
 			break
 		}
 	}

--- a/marshal/marshal_test.go
+++ b/marshal/marshal_test.go
@@ -157,3 +157,10 @@ func (s *MarshalSuite) TestPartitionLifecycleIntegration(c *C) {
 		c.Error("LastOffset is not 20")
 	}
 }
+
+func (s *MarshalSuite) TestTerminatedMarshalRemovesSelfFromCluster(c *C) {
+	// Test that terminated Marshalers remove their cluster's reference to it.
+	c.Assert(s.m.cluster.marshalers, DeepEquals, []*Marshaler{s.m})
+	s.m.Terminate()
+	c.Assert(s.m.cluster.marshalers, DeepEquals, []*Marshaler{})
+}


### PR DESCRIPTION
Updates Terminate() in Consumer and Marshal, so that a terminating Consumer removes its Marshal's reference to it (the same applies for a terminating Marshal with its Cluster). Adds terminateAndCleanup to both structs to accomplish this.

Ran full unit test suite, which includes new tests for this behavior. 
GOMAXPROCS=4 go test -p=1 --race