### PR TITLE
Have fast-reclaim honor MaximumClaims for topic claims

### DIFF
--- a/marshal/consumer.go
+++ b/marshal/consumer.go
@@ -145,7 +145,15 @@ func (m *Marshaler) NewConsumer(topicNames []string, options ConsumerOptions) (*
 					}
 				}
 			}
+
+			// this check needs to be after iterating all partitions in a topic
+			if len(c.claimedTopics) >= options.MaximumClaims {
+				log.Infof("reached max-topics for fast-reclaim. Claimed topics: %v",
+					c.claimedTopics)
+				break
+			}
 		}
+
 		// send topic claim notification
 		if options.ClaimEntireTopic && len(c.claimedTopics) > 0 {
 			c.lock.RLock()

--- a/marshal/consumer.go
+++ b/marshal/consumer.go
@@ -147,7 +147,7 @@ func (m *Marshaler) NewConsumer(topicNames []string, options ConsumerOptions) (*
 			}
 
 			// this check needs to be after iterating all partitions in a topic
-			if len(c.claimedTopics) >= options.MaximumClaims {
+			if options.ClaimEntireTopic && len(c.claimedTopics) >= options.MaximumClaims {
 				log.Infof("reached max-topics for fast-reclaim. Claimed topics: %v",
 					c.claimedTopics)
 				break


### PR DESCRIPTION
In the case where we reduce the number of MaximumClaims, we need to have marshal honor the lower MaximumClaims even if it claimed more topics earlier.