### PR TITLE
Adjust health check and add verbosity

### DIFF
--- a/marshal/claim_test.go
+++ b/marshal/claim_test.go
@@ -361,9 +361,17 @@ func (s *ClaimSuite) TestHealthCheck(c *C) {
 	c.Assert(s.cl.healthCheck(), Equals, true)
 	c.Assert(s.cl.cyclesBehind, Equals, 0)
 
-	// Now we're behind and fail health checks 3 times, this will release
+	// Test that "predictive speed" is working, i.e., that the consumer is
+	// considered healthy when it's within a heartbeat of the end
 	s.cl.offsets.Latest = 31
 	s.cl.offsetLatestHistory = [10]int64{1, 11, 21, 31, 0, 0, 0, 0, 0, 0}
+	c.Assert(s.cl.ConsumerVelocity() < s.cl.PartitionVelocity(), Equals, true)
+	c.Assert(s.cl.healthCheck(), Equals, true)
+	c.Assert(s.cl.cyclesBehind, Equals, 0)
+
+	// Now we're behind and fail health checks 3 times, this will release
+	s.cl.offsets.Latest = 32
+	s.cl.offsetLatestHistory = [10]int64{1, 11, 21, 32, 0, 0, 0, 0, 0, 0}
 	c.Assert(s.cl.ConsumerVelocity() < s.cl.PartitionVelocity(), Equals, true)
 	c.Assert(s.cl.healthCheck(), Equals, true)
 	c.Assert(s.cl.cyclesBehind, Equals, 1)

--- a/marshal/consumer.go
+++ b/marshal/consumer.go
@@ -315,6 +315,8 @@ func (c *Consumer) claimPartitions() {
 		// claiming this partition
 		if lastClaim.GroupID == c.marshal.groupID &&
 			lastClaim.ClientID == c.marshal.clientID {
+			log.Infof("skipping unclaimed partition %s:%d because we previously released it",
+				topic, partID)
 			continue
 		}
 


### PR DESCRIPTION
This updates the health check by predicting a consumer offset at the
next heartbeat period. This is done by taking the current velocity and
adding it to the current offset. If this is greater than the end of the
partition, we consider the consumer healthy. This should address the
issues with consumer health oscillation in some cases.

Additionally, this adds a number of metrics to the heartbeat logs and in
a few more case statements to hopefully help people debug issues more
easily.