### PR TITLE
send topic updates after claiming partition 0 immediately

### DIFF
--- a/marshal/consumer.go
+++ b/marshal/consumer.go
@@ -476,12 +476,15 @@ func (c *Consumer) updateTopicClaims(latestClaims map[string]bool, force bool) {
 			}
 
 			// let's write a copy of the map because we need to differentiate in the future
-			// between latestClaims and c.claimedTopics
-			c.claimedTopics = make(map[string]bool, len(c.claimedTopics))
+			// between latestClaims and c.claimedTopics. We should also give out a new copy
+			// to avoid having clients modify the claims unintentionally
+			c.claimedTopics = make(map[string]bool, len(latestClaims))
+			newClaims := make(map[string]bool, len(latestClaims))
 			for topic, claimed := range latestClaims {
 				c.claimedTopics[topic] = claimed
+				newClaims[topic] = claimed
 			}
-			c.topicClaimsChan <- latestClaims
+			c.topicClaimsChan <- newClaims
 		}()
 	}
 }

--- a/marshal/consumer.go
+++ b/marshal/consumer.go
@@ -141,6 +141,7 @@ func (m *Marshaler) NewConsumer(topicNames []string, options ConsumerOptions) (*
 					if options.ClaimEntireTopic {
 						if partID == 0 {
 							c.claimedTopics[topic] = true
+							c.safeUpdateTopicClaims(c.claimedTopics, true)
 						}
 
 						// don't fast re-claim partitions for a topic unless partition 0 is claimed
@@ -163,14 +164,6 @@ func (m *Marshaler) NewConsumer(topicNames []string, options ConsumerOptions) (*
 					c.claimedTopics)
 				break
 			}
-		}
-
-		// send topic claim notification
-		if options.ClaimEntireTopic && len(c.claimedTopics) > 0 {
-			c.lock.RLock()
-			defer c.lock.RUnlock()
-			// updateTopicClaims expects to be called with RLock held
-			c.updateTopicClaims(c.claimedTopics, true)
 		}
 	}
 
@@ -394,6 +387,9 @@ func (c *Consumer) claimTopics() {
 				continue
 			}
 			latestClaims[topic] = true
+			if !c.Terminated() {
+				c.safeUpdateTopicClaims(latestClaims, false)
+			}
 		} else {
 			// Unclaimed, so attempt to claim partition 0. This is how we key topic claims.
 			log.Infof("[%s] attempting to claim topic (key partition 0)\n", topic)
@@ -413,6 +409,9 @@ func (c *Consumer) claimTopics() {
 			}
 			log.Infof("[%s] claimed topic (key partition 0) successfully\n", topic)
 			latestClaims[topic] = true
+			if !c.Terminated() {
+				c.safeUpdateTopicClaims(latestClaims, false)
+			}
 		}
 
 		// We either just claimed or we have already owned the 0th partition. Let's iterate
@@ -424,14 +423,16 @@ func (c *Consumer) claimTopics() {
 			}
 		}
 	}
+}
 
-	if !c.Terminated() {
-		c.lock.RLock()
-		defer c.lock.RUnlock()
-		// let's compare the new topic claims vs old ones. Upon change, we should trigger an update
-		// updateTopicClaims expects to be called with RLock held
-		c.updateTopicClaims(latestClaims, false)
-	}
+// updatesTopicClaims if changed. It should be noted that it expects c.lock.RLock
+// to be already acquired
+func (c *Consumer) safeUpdateTopicClaims(latestClaims map[string]bool, force bool) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	// let's compare the new topic claims vs old ones. Upon change, we should trigger an update
+	// updateTopicClaims expects to be called with RLock held
+	c.updateTopicClaims(latestClaims, force)
 }
 
 // updatesTopicClaims if changed. It should be noted that it expects c.lock.RLock

--- a/marshal/consumer_test.go
+++ b/marshal/consumer_test.go
@@ -281,10 +281,13 @@ func (s *ConsumerSuite) TestMultiTopicClaim(c *C) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		select {
-		case claimedTopics := <-cn.TopicClaims():
-			c.Assert(len(claimedTopics), Equals, len(topics))
-			break
+		for i := range topics {
+			select {
+			case claimedTopics := <-cn.TopicClaims():
+				// we should get topic claims one by one
+				c.Assert(len(claimedTopics), Equals, i+1)
+				break
+			}
 		}
 	}()
 

--- a/marshal/consumer_test.go
+++ b/marshal/consumer_test.go
@@ -285,6 +285,7 @@ func (s *ConsumerSuite) TestMultiTopicClaim(c *C) {
 			select {
 			case claimedTopics := <-cn.TopicClaims():
 				// we should get topic claims one by one
+				log.Infof("received topic claims: %v\n", claimedTopics)
 				c.Assert(len(claimedTopics), Equals, i+1)
 				break
 			}


### PR DESCRIPTION
Instead of waiting until claiming all partitions for all topics, then send topic updates, send the updates immediately.