### PR TITLE
Send topic updates after claiming partition 0 immediately

### DIFF
--- a/marshal/consumer_test.go
+++ b/marshal/consumer_test.go
@@ -281,10 +281,14 @@ func (s *ConsumerSuite) TestMultiTopicClaim(c *C) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		select {
-		case claimedTopics := <-cn.TopicClaims():
-			c.Assert(len(claimedTopics), Equals, len(topics))
-			break
+		for i := range topics {
+			select {
+			case claimedTopics := <-cn.TopicClaims():
+				// we should get topic claims one by one
+				log.Infof("received topic claims: %v\n", claimedTopics)
+				c.Assert(len(claimedTopics), Equals, i+1)
+				break
+			}
 		}
 	}()
 


### PR DESCRIPTION
This is done for performance since claiming topics can take some time.