### PR TITLE
Add ReleaseClaimsIfBehind to ConsumerOptions

### DIFF
--- a/marshal/claim.go
+++ b/marshal/claim.go
@@ -431,7 +431,7 @@ func (c *claim) healthCheck() bool {
 
 	// In topic claim mode we don't do any velocity checking. It's up to the consumer
 	// to ensure they're claiming. TODO: Unclear if this is correct or not.
-	if c.options.ClaimEntireTopic {
+	if c.options.ClaimEntireTopic || !c.options.ReleaseClaimsIfBehind {
 		return true
 	}
 

--- a/marshal/claim_test.go
+++ b/marshal/claim_test.go
@@ -388,7 +388,13 @@ func (s *ClaimSuite) TestHealthCheck(c *C) {
 	opts := NewConsumerOptions()
 	opts.ReleaseClaimsIfBehind = false
 	s.cl = newClaim("test16", 0, s.m, s.ch, opts)
-	c.Assert(s.cl.healthCheck(), Equals, true)
+	c.Assert(s.cl, NotNil)
+	s.cl.offsetLatestHistory = [10]int64{1, 10, 0, 0, 0, 0, 0, 0, 0, 0}
+	s.cl.offsetCurrentHistory = [10]int64{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+	s.cl.offsets.Current = 0
+    	s.cl.offsets.Latest = 10
+	c.Assert(s.cl.ConsumerVelocity() < s.cl.PartitionVelocity(), Equals, true)
+    	c.Assert(s.cl.healthCheck(), Equals, true)
 }
 
 func (s *ClaimSuite) TestHealthCheckRelease(c *C) {

--- a/marshal/claim_test.go
+++ b/marshal/claim_test.go
@@ -383,6 +383,12 @@ func (s *ClaimSuite) TestHealthCheck(c *C) {
 	c.Assert(s.m.GetPartitionClaim("test16", 0).LastHeartbeat, Equals, int64(0))
 	c.Assert(s.m.GetPartitionClaim("test16", 0).LastOffset, Equals, int64(0))
 	c.Assert(s.m.GetLastPartitionClaim("test16", 0).LastOffset, Equals, int64(21))
+
+	// If we are okay with CV<PV we shouldn't release
+	opts := NewConsumerOptions()
+	opts.ReleaseClaimsIfBehind = false
+	s.cl = newClaim("test16", 0, s.m, s.ch, opts)
+	c.Assert(s.cl.healthCheck(), Equals, true)
 }
 
 func (s *ClaimSuite) TestHealthCheckRelease(c *C) {

--- a/marshal/consumer.go
+++ b/marshal/consumer.go
@@ -71,6 +71,10 @@ type ConsumerOptions struct {
 	// consumption parallelism.
 	StrictOrdering bool
 
+	// ReleaseClaimsIfBehind indicates whether to release a claim if a consumer
+	// is consuming at a rate slower than the partition is being produced to.
+	ReleaseClaimsIfBehind bool
+
 	// The maximum number of claims this Consumer is allowed to hold simultaneously.
 	// MaximumClaims indicates the maximum number of partitions to be claimed when
 	// ClaimEntireTopic is set to false. Otherwise, it indicates the maximum number
@@ -196,10 +200,11 @@ func (m *Marshaler) NewConsumer(topicNames []string, options ConsumerOptions) (*
 // NewConsumerOptions returns a default set of options for the Consumer.
 func NewConsumerOptions() ConsumerOptions {
 	return ConsumerOptions{
-		FastReclaim:      true,
-		ClaimEntireTopic: false,
-		GreedyClaims:     false,
-		StrictOrdering:   false,
+		FastReclaim:           true,
+		ClaimEntireTopic:      false,
+		GreedyClaims:          false,
+		StrictOrdering:        false,
+		ReleaseClaimsIfBehind: true,
 	}
 }
 


### PR DESCRIPTION
This allows for slow-consuming consumers. The current behavior is to release a claim if we are consuming slower than the produce rate.