### PR TITLE
Release topic in topic mode

### DIFF
--- a/marshal/claim.go
+++ b/marshal/claim.go
@@ -42,13 +42,14 @@ type claim struct {
 	messagesLock  *sync.Mutex
 	offsets       PartitionOffsets
 	marshal       *Marshaler
+	consumer      *Consumer
 	rand          *rand.Rand
 	claimed       *int32
 	terminated    *int32
 	beatCounter   int32
 	lastHeartbeat int64
 	options       ConsumerOptions
-	consumer      kafka.Consumer
+	kafkaConsumer kafka.Consumer
 	messages      chan *Message
 
 	// tracking is a dict that maintains information about offsets that have been
@@ -70,7 +71,7 @@ type claim struct {
 
 // newClaim returns an internal claim object, used by the consumer to manage the
 // claim of a single partition.
-func newClaim(topic string, partID int, marshal *Marshaler,
+func newClaim(topic string, partID int, marshal *Marshaler, consumer *Consumer,
 	messages chan *Message, options ConsumerOptions) *claim {
 	// Get all available offset information
 	offsets, err := marshal.GetPartitionOffsets(topic, partID)
@@ -102,6 +103,7 @@ func newClaim(topic string, partID int, marshal *Marshaler,
 		lock:         &sync.RWMutex{},
 		messagesLock: &sync.Mutex{},
 		marshal:      marshal,
+		consumer:     consumer,
 		topic:        topic,
 		partID:       partID,
 		claimed:      new(int32),
@@ -165,7 +167,7 @@ func (c *claim) setup() {
 		atomic.StoreInt32(c.claimed, 0)
 		return
 	}
-	c.consumer = kafkaConsumer
+	c.kafkaConsumer = kafkaConsumer
 
 	// Start our maintenance goroutines that keep this system healthy
 	go c.healthCheckLoop()
@@ -241,7 +243,7 @@ func (c *claim) Terminate() bool {
 	return c.teardown(false)
 }
 
-// internal function that will teardown the claim. It may release the partition or
+// teardown handles releasing the claim or just updating our offsets for a fast restart.
 func (c *claim) teardown(releasePartition bool) bool {
 	if !atomic.CompareAndSwapInt32(c.terminated, 0, 1) {
 		return false
@@ -259,6 +261,13 @@ func (c *claim) teardown(releasePartition bool) bool {
 	// is reasonable. Held because of using offsetCurrent below.
 	c.lock.RLock()
 	defer c.lock.RUnlock()
+
+	// Advise the consumer that this claim is terminating, this is so that the consumer
+	// can release other claims if we've lost part of a topic
+	if c.consumer != nil {
+		go c.consumer.claimTerminated(c, releasePartition)
+	}
+
 	var err error
 	if releasePartition {
 		log.Infof("[%s:%d] releasing partition claim", c.topic, c.partID)
@@ -282,7 +291,7 @@ func (c *claim) messagePump() {
 	// be running while someone else has the lock, and we can't get it ourselves, we are
 	// forbidden to touch anything other than the consumer and the message channel.
 	for c.Claimed() {
-		msg, err := c.consumer.Consume()
+		msg, err := c.kafkaConsumer.Consume()
 		if err == proto.ErrOffsetOutOfRange {
 			// Fell out of range, presumably because we're handling this too slow, so
 			// let's abandon this consumer

--- a/marshal/claim.go
+++ b/marshal/claim.go
@@ -70,7 +70,9 @@ type claim struct {
 }
 
 // newClaim returns an internal claim object, used by the consumer to manage the
-// claim of a single partition.
+// claim of a single partition. It is up to the caller to ensure healthCheckLoop gets
+// called in a goroutine. If you do not, the claim will die from failing to heartbeat
+// after a short period.
 func newClaim(topic string, partID int, marshal *Marshaler, consumer *Consumer,
 	messages chan *Message, options ConsumerOptions) *claim {
 	// Get all available offset information
@@ -170,7 +172,6 @@ func (c *claim) setup() {
 	c.kafkaConsumer = kafkaConsumer
 
 	// Start our maintenance goroutines that keep this system healthy
-	go c.healthCheckLoop()
 	go c.messagePump()
 
 	// Totally done, let the world know and move on

--- a/marshal/claim_test.go
+++ b/marshal/claim_test.go
@@ -387,7 +387,7 @@ func (s *ClaimSuite) TestHealthCheck(c *C) {
 	// If we are okay with CV<PV we shouldn't release
 	opts := NewConsumerOptions()
 	opts.ReleaseClaimsIfBehind = false
-	s.cl = newClaim("test16", 0, s.m, s.ch, opts)
+	s.cl = newClaim("test16", 0, s.m, nil, s.ch, opts)
 	c.Assert(s.cl, NotNil)
 	s.cl.offsetLatestHistory = [10]int64{1, 10, 0, 0, 0, 0, 0, 0, 0, 0}
 	s.cl.offsetCurrentHistory = [10]int64{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}

--- a/marshal/claim_test.go
+++ b/marshal/claim_test.go
@@ -26,7 +26,7 @@ func (s *ClaimSuite) SetUpTest(c *C) {
 	var err error
 	s.m, err = NewMarshaler("cl", "gr", []string{s.s.Addr()})
 	c.Assert(err, IsNil)
-	s.cl = newClaim("test16", 0, s.m, s.ch, NewConsumerOptions())
+	s.cl = newClaim("test16", 0, s.m, nil, s.ch, NewConsumerOptions())
 	c.Assert(s.cl, NotNil)
 }
 

--- a/marshal/consumer.go
+++ b/marshal/consumer.go
@@ -94,21 +94,19 @@ type ConsumerOptions struct {
 // processes as might be consuming from this topic. However, you should ONLY create one
 // Consumer per topic in your application!
 type Consumer struct {
-	alive      *int32
-	marshal    *Marshaler
-	topics     []string
-	partitions map[string]int
-	rand       *rand.Rand
-	options    ConsumerOptions
-	messages   chan *Message
+	alive              *int32
+	marshal            *Marshaler
+	topics             []string
+	options            ConsumerOptions
+	messages           chan *Message
+	topicClaimsChan    chan map[string]bool
+	topicClaimsUpdated chan struct{}
 
-	// claims maps partition IDs to claim structures. The lock protects read/write
-	// access to this map.
-	lock   sync.RWMutex
-	claims map[string]map[int]*claim
-	// caches the claimed topics
-	claimedTopics   map[string]bool
-	topicClaimsChan chan map[string]bool
+	// lock protects access to the following mutables.
+	lock       sync.RWMutex
+	rand       *rand.Rand
+	partitions map[string]int
+	claims     map[string]map[int]*claim
 }
 
 // NewConsumer instantiates a consumer object for a given topic. You must create a
@@ -133,23 +131,32 @@ func (m *Marshaler) NewConsumer(topicNames []string, options ConsumerOptions) (*
 
 	// Construct base structure
 	c := &Consumer{
-		alive:           new(int32),
-		marshal:         m,
-		topics:          topicNames,
-		partitions:      partitions,
-		options:         options,
-		messages:        make(chan *Message, 10000),
-		rand:            rand.New(rand.NewSource(time.Now().UnixNano())),
-		claims:          make(map[string]map[int]*claim),
-		claimedTopics:   make(map[string]bool),
-		topicClaimsChan: make(chan map[string]bool, 1),
+		alive:              new(int32),
+		marshal:            m,
+		topics:             topicNames,
+		partitions:         partitions,
+		options:            options,
+		messages:           make(chan *Message, 10000),
+		rand:               rand.New(rand.NewSource(time.Now().UnixNano())),
+		claims:             make(map[string]map[int]*claim),
+		topicClaimsChan:    make(chan map[string]bool, 1),
+		topicClaimsUpdated: make(chan struct{}, 1),
 	}
 	atomic.StoreInt32(c.alive, 1)
 	m.addNewConsumer(c)
 
+	// Take the lock for now as we're updating various points internally
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	// Start notifier about topic claims now because people are going to start
+	// listening immediately
+	go c.sendTopicClaimsLoop()
+
 	// Fast-reclaim: iterate over existing claims in the given topics and see if
 	// any of them look to be ours. Do this before the claim manager kicks off.
 	if c.options.FastReclaim {
+		claimedTopics := make(map[string]bool)
 		for topic, partitionCount := range c.partitions {
 			for partID := 0; partID < partitionCount; partID++ {
 				cl := c.marshal.GetPartitionClaim(topic, partID)
@@ -166,12 +173,11 @@ func (m *Marshaler) NewConsumer(topicNames []string, options ConsumerOptions) (*
 					// update topic claims
 					if options.ClaimEntireTopic {
 						if partID == 0 {
-							c.claimedTopics[topic] = true
-							c.safeUpdateTopicClaims(c.claimedTopics, true)
+							claimedTopics[topic] = true
 						}
 
 						// don't fast re-claim partitions for a topic unless partition 0 is claimed
-						if !c.claimedTopics[topic] {
+						if !claimedTopics[topic] {
 							log.Infof("[%s:%d] blocked fast-reclaim because topic is not claimed",
 								topic, partID)
 							continue
@@ -179,15 +185,15 @@ func (m *Marshaler) NewConsumer(topicNames []string, options ConsumerOptions) (*
 					}
 
 					c.claims[topic][partID] = newClaim(
-						topic, partID, c.marshal, c.messages, options)
-
+						topic, partID, c.marshal, c, c.messages, options)
+					c.sendTopicClaimsUpdate()
 				}
 			}
 
 			// this check needs to be after iterating all partitions in a topic
-			if options.ClaimEntireTopic && len(c.claimedTopics) >= options.MaximumClaims {
+			if options.ClaimEntireTopic && len(claimedTopics) >= options.MaximumClaims {
 				log.Infof("reached max-topics for fast-reclaim. Claimed topics: %v",
-					c.claimedTopics)
+					claimedTopics)
 				break
 			}
 		}
@@ -211,6 +217,7 @@ func NewConsumerOptions() ConsumerOptions {
 func (c *Consumer) defaultTopic() string {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
+
 	if len(c.partitions) > 1 {
 		log.Errorf("attempted to claim partitions for more than one topic")
 		go c.Terminate(false)
@@ -229,6 +236,7 @@ func (c *Consumer) defaultTopic() string {
 func (c *Consumer) defaultTopicPartitions() int {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
+
 	if len(c.partitions) > 1 {
 		log.Errorf("attempted to claim partitions for more than one topic")
 		go c.Terminate(false)
@@ -242,6 +250,31 @@ func (c *Consumer) defaultTopicPartitions() int {
 	log.Errorf("couldn't find default topic!")
 	go c.Terminate(false)
 	return 0
+}
+
+// claimTerminated is called by a claim when they've terminated. This is used so we can
+// ensure topic claim semantics are adhered to. In topic claim mode this will be called
+// by every claim during a release.
+func (c *Consumer) claimTerminated(cl *claim, released bool) {
+	// For now, we don't care except in the topic claim mode
+	if !c.options.ClaimEntireTopic {
+		return
+	}
+
+	// This is a topic claim, so we need to perform the same operation on the rest of
+	// the claims in this topic
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	for _, claim := range c.claims[cl.topic] {
+		if cl != claim {
+			if released {
+				go claim.Release()
+			} else {
+				go claim.Terminate()
+			}
+		}
+	}
+	c.sendTopicClaimsUpdate()
 }
 
 // tryClaimPartition attempts to claim a partition and make it available in the consumption
@@ -267,7 +300,7 @@ func (c *Consumer) tryClaimPartition(topic string, partID int) bool {
 
 	// Set up internal claim structure we'll track things in, this can block for a while
 	// as it talks to Kafka and waits for rationalizers.
-	newClaim := newClaim(topic, partID, c.marshal, c.messages, c.options)
+	newClaim := newClaim(topic, partID, c.marshal, c, c.messages, c.options)
 	if newClaim == nil {
 		return false
 	}
@@ -338,6 +371,7 @@ func (c *Consumer) claimPartitions() {
 	if partitions <= 0 {
 		return
 	}
+
 	// Don't bother trying to make claims if we are at our claim limit.
 	// This is just an optimization, because we aren't holding the lock here
 	// this check is repeated inside tryClaimPartition.
@@ -403,22 +437,21 @@ func (c *Consumer) isTopicClaimLimitReached(topic string) bool {
 // as the key, anybody who has that partition has claimed the entire topic. This requires all
 // consumers to use this mode.
 func (c *Consumer) claimTopics() {
-	// let's make a copy of what's in c.claimedTopics
-	latestClaims := make(map[string]bool)
-	if !c.Terminated() {
-		func() {
-			c.lock.RLock()
-			defer c.lock.RUnlock()
-			for topic, claimed := range c.claimedTopics {
-				latestClaims[topic] = claimed
-			}
-		}()
-	}
+	// Get a copy of c.partitions so we don't have to hold the lock throughout
+	// this entire method
+	topic_partitions := make(map[string]int)
+	func() {
+		c.lock.RLock()
+		defer c.lock.RUnlock()
 
-	for topic, partitions := range c.partitions {
+		for k, v := range c.partitions {
+			topic_partitions[k] = v
+		}
+	}()
+
+	// Now iterate each and try to claim
+	for topic, partitions := range topic_partitions {
 		if partitions <= 0 {
-			delete(latestClaims, topic)
-			c.safeUpdateTopicClaims(latestClaims, false)
 			continue
 		}
 
@@ -430,12 +463,9 @@ func (c *Consumer) claimTopics() {
 			if lastClaim.GroupID != c.marshal.groupID ||
 				lastClaim.ClientID != c.marshal.clientID {
 				// in case we had this topic, but now somebody else has claimed it
-				delete(latestClaims, topic)
-				c.safeUpdateTopicClaims(latestClaims, false)
+				c.sendTopicClaimsUpdate()
 				continue
 			}
-			// topic has already been claimed. No need to send notification.
-			latestClaims[topic] = true
 		} else {
 			// Unclaimed, so attempt to claim partition 0. This is how we key topic claims.
 			log.Infof("[%s] attempting to claim topic (key partition 0)\n", topic)
@@ -454,9 +484,8 @@ func (c *Consumer) claimTopics() {
 				continue
 			}
 			log.Infof("[%s] claimed topic (key partition 0) successfully\n", topic)
-			latestClaims[topic] = true
 			// a new partition claim, let's send topic claim notification if necessary
-			c.safeUpdateTopicClaims(latestClaims, false)
+			c.sendTopicClaimsUpdate()
 		}
 
 		// We either just claimed or we have already owned the 0th partition. Let's iterate
@@ -470,78 +499,59 @@ func (c *Consumer) claimTopics() {
 	}
 }
 
-// updatesTopicClaims if changed. It should be noted that it expects c.lock.RLock
-// to be already acquired
-func (c *Consumer) safeUpdateTopicClaims(latestClaims map[string]bool, force bool) {
-	if !c.Terminated() {
-		c.lock.RLock()
-		defer c.lock.RUnlock()
-		// let's compare the new topic claims vs old ones. Upon change, we should trigger an update
-		// updateTopicClaims expects to be called with RLock held
-		c.updateTopicClaims(latestClaims, force)
+// sendTopicClaimUpdate can be called by various codepaths that have learned that there is
+// an update to send down to the users.
+func (c *Consumer) sendTopicClaimsUpdate() {
+	if c.Terminated() {
+		return
+	}
+
+	select {
+	case c.topicClaimsUpdated <- struct{}{}:
+		// Just sends a marker on the channel.
+	default:
 	}
 }
 
-// updatesTopicClaims if changed. It should be noted that it expects c.lock.RLock
-// to be already acquired
-func (c *Consumer) updateTopicClaims(latestClaims map[string]bool, force bool) {
-	changed := false
-	if force {
-		changed = true
-	} else {
-		// check for missing topic claims
-		for topic := range c.claimedTopics {
-			if !latestClaims[topic] {
-				changed = true
-				break
-			}
+// topicClaimsLoop sends an updated topic claim map every time we get a notification.
+func (c *Consumer) sendTopicClaimsLoop() {
+	defer close(c.topicClaimsChan)
+
+	for range c.topicClaimsUpdated {
+		// Get consistent claims and send them
+		claims, err := c.GetCurrentTopicClaims()
+		if err != nil {
+			log.Errorf("Failed to send topic claims update: %s", err)
+			continue
 		}
 
-		if !changed {
-			// let's check if something in latest that is not in claimedTopics.
-			// checking for length only is not sufficient
-			for topic := range latestClaims {
-				if !c.claimedTopics[topic] {
-					changed = true
-					break
-				}
-			}
-		}
-	}
-
-	if changed {
-		log.Infof("updating topic claims: %v\n", latestClaims)
-		c.lock.RUnlock()
-		defer c.lock.RLock()
-		func() {
-			// make sure that draining the channel and writing to it
-			// happens in the same atomic operation
-			c.lock.Lock()
-			defer c.lock.Unlock()
-
+		// Drain out any unconsumed updates
+	CONSUME:
+		for {
 			select {
 			case <-c.topicClaimsChan:
 			default:
+				break CONSUME
 			}
+		}
 
-			// let's write a copy of the map because we need to differentiate in the future
-			// between latestClaims and c.claimedTopics. We should also give out a new copy
-			// to avoid having clients modify the claims unintentionally
-			c.claimedTopics = make(map[string]bool, len(latestClaims))
-			newClaims := make(map[string]bool, len(latestClaims))
-			for topic, claimed := range latestClaims {
-				c.claimedTopics[topic] = claimed
-				newClaims[topic] = claimed
-			}
-			c.topicClaimsChan <- newClaims
-		}()
+		// This should never block since we're the only writer
+		c.topicClaimsChan <- claims
+
+		// This is at the end of the loop because we want to send one final update
+		// as we're exiting (which we've already done above)
+		if c.Terminated() {
+			return
+		}
 	}
 }
 
 // updatePartitionCounts pulls the latest partition counts per topic from the Marshaler
 func (c *Consumer) updatePartitionCounts() {
+	// Write lock as we're updating c.partitions below, potentially
 	c.lock.Lock()
 	defer c.lock.Unlock()
+
 	for _, topic := range c.marshal.Topics() {
 		// Only update partitions for topics we already know about
 		if _, ok := c.partitions[topic]; ok {
@@ -618,12 +628,10 @@ func (c *Consumer) terminateAndCleanup(release bool, remove bool) bool {
 		c.marshal.removeConsumer(c)
 	}
 
-	// update the claims
-	// updateTopicClaims expects to be called with RLock held
-	c.updateTopicClaims(latestTopicClaims, false)
-	close(c.topicClaimsChan)
+	// Update the claims one last time
+	c.sendTopicClaimsUpdate()
+	close(c.topicClaimsUpdated)
 	return true
-
 }
 
 // Terminate instructs the consumer to clean up and allow other consumers to begin consuming.
@@ -636,28 +644,37 @@ func (c *Consumer) Terminate(release bool) bool {
 // consumer. It should be relevent only when ClaimEntireTopic is set
 func (c *Consumer) GetCurrentTopicClaims() (map[string]bool, error) {
 	if !c.options.ClaimEntireTopic {
-		err := fmt.Errorf("GetCurrentTopicClaims is only relevent when ClaimEntireTopic is set")
-		log.Error(err.Error())
-		return nil, err
+		return nil, errors.New(
+			"GetCurrentTopicClaims requires options.ClaimEntireTopic be set")
+	}
+
+	claimedTopics := make(map[string]bool)
+	if c.Terminated() {
+		return claimedTopics, nil
 	}
 
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 
-	// do a copy
-	latestClaims := make(map[string]bool)
-	for topic := range c.claimedTopics {
-		latestClaims[topic] = true
+	// Iterate each topic we know about and see if we have partition 0 claimed
+	// for that topic, if so, consider it valid
+	for topic, _ := range c.partitions {
+		cl := c.marshal.GetPartitionClaim(topic, 0)
+		if cl.ClientID == c.marshal.ClientID() &&
+			cl.GroupID == c.marshal.GroupID() {
+			// We own this topic
+			claimedTopics[topic] = true
+		}
 	}
-
-	return latestClaims, nil
+	return claimedTopics, nil
 }
 
 // TopicClaims returns a read-only channel that receives updates for topic claims.
 // It's only relevant when CLaimEntireTopic is set
 func (c *Consumer) TopicClaims() <-chan map[string]bool {
 	if !c.options.ClaimEntireTopic {
-		err := fmt.Errorf("GetCurrentTopicClaims is only relevant when ClaimEntireTopic is set")
+		err := fmt.Errorf(
+			"GetCurrentTopicClaims is only relevant when ClaimEntireTopic is set")
 		log.Error(err.Error())
 	}
 

--- a/marshal/consumer_test.go
+++ b/marshal/consumer_test.go
@@ -181,7 +181,9 @@ func (s *ConsumerSuite) TestTopicClaimBlocked(c *C) {
 
 	// Claim an entire topic, this creates a real consumer
 	cn := s.NewTestConsumer(s.m2, []string{topic})
+	cn.lock.Lock()
 	cn.options.ClaimEntireTopic = true
+	cn.lock.Unlock()
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
@@ -246,7 +248,9 @@ func (s *ConsumerSuite) TestTopicClaimPartial(c *C) {
 
 	// Claim an entire topic, this creates a real consumer
 	cn := s.NewTestConsumer(s.m2, []string{topic})
+	cn.lock.Lock()
 	cn.options.ClaimEntireTopic = true
+	cn.lock.Unlock()
 	defer cn.Terminate(true)
 
 	// Force our consumer to run it's topic claim loop so we know it has run
@@ -287,7 +291,9 @@ func (s *ConsumerSuite) TestMultiTopicClaim(c *C) {
 	// Claim partition 1 with one consumer
 	topics := []string{"test1", "test2", "test16"}
 	cn := s.NewTestConsumer(s.m, topics)
+	cn.lock.Lock()
 	cn.options.ClaimEntireTopic = true
+	cn.lock.Unlock()
 	defer cn.Terminate(true)
 	wg := sync.WaitGroup{}
 	wg.Add(1)
@@ -344,8 +350,10 @@ func (s *ConsumerSuite) TestMultiTopicClaimWithLimit(c *C) {
 	// Claim partition 1 with one consumer
 	topics := []string{"test1", "test2", "test16"}
 	cn := s.NewTestConsumer(s.m, topics)
+	cn.lock.Lock()
 	cn.options.ClaimEntireTopic = true
 	cn.options.MaximumClaims = 2
+	cn.lock.Unlock()
 	defer cn.Terminate(true)
 
 	// Force our consumer to run it's topic claim loop so we know it has run
@@ -527,7 +535,9 @@ func (s *ConsumerSuite) TestCommitByToken(c *C) {
 
 func (s *ConsumerSuite) TestStrictOrdering(c *C) {
 	// Test that we can strict ordering semantics
+	s.cn.lock.Lock()
 	s.cn.options.StrictOrdering = true
+	s.cn.lock.Unlock()
 	s.Produce("test16", 0, "m1", "m2", "m3", "m4")
 	s.Produce("test16", 1, "m1", "m2", "m3", "m4")
 	c.Assert(s.cn.tryClaimPartition(s.cn.defaultTopic(), 0), Equals, true)
@@ -570,7 +580,9 @@ func (s *ConsumerSuite) TestTryClaimPartition(c *C) {
 
 func (s *ConsumerSuite) TestAggressiveClaim(c *C) {
 	// Ensure aggressive mode claims all partitions in a single call to claim
+	s.cn.lock.Lock()
 	s.cn.options.GreedyClaims = true
+	s.cn.lock.Unlock()
 	c.Assert(s.cn.GetCurrentLoad(), Equals, 0)
 	s.cn.claimPartitions()
 	c.Assert(s.cn.GetCurrentLoad(), Equals, 16)
@@ -643,7 +655,9 @@ func (s *ConsumerSuite) TestFastReclaim(c *C) {
 
 func (s *ConsumerSuite) TestMaximumClaims(c *C) {
 	// Test the MaximumClaims option.
+	s.cn.lock.Lock()
 	s.cn.options.MaximumClaims = 2
+	s.cn.lock.Unlock()
 	c.Assert(s.cn.isClaimLimitReached(), Equals, false)
 	c.Assert(s.cn.getNumActiveClaims(), Equals, 0)
 	s.cn.claimPartitions()
@@ -659,8 +673,10 @@ func (s *ConsumerSuite) TestMaximumClaims(c *C) {
 
 func (s *ConsumerSuite) TestMaximumGreedyClaims(c *C) {
 	// Test the MaximumClaims option combined with GreedyClaims.
+	s.cn.lock.Lock()
 	s.cn.options.MaximumClaims = 2
 	s.cn.options.GreedyClaims = true
+	s.cn.lock.Unlock()
 	c.Assert(s.cn.isClaimLimitReached(), Equals, false)
 	c.Assert(s.cn.getNumActiveClaims(), Equals, 0)
 	s.cn.claimPartitions()


### PR DESCRIPTION
Sometimes we need to release a single partition in topic claim mode for
one reason or another (failed heartbeat, somebody else claimed, etc). It
was previously possible to end up in a split brain situation where we
release partitions >0 and nobody else will ever claim them due to the
way topic claim works.

This update makes it so that if we're in topic claim mode and we release
any partition, we will kick off releases for all of them.