### PR TITLE
Add options to cluster dialer

### DIFF
--- a/marshal/claim.go
+++ b/marshal/claim.go
@@ -153,9 +153,7 @@ func (c *claim) setup() {
 	// Set up Kafka consumer
 	consumerConf := kafka.NewConsumerConf(c.topic, int32(c.partID))
 	consumerConf.StartOffset = c.offsets.Current
-	// Long-poll fetch for a few seconds. This balances the QPS against Kafka with the
-	// number of connections we have to tie up.
-	consumerConf.RequestTimeout = 3 * time.Second
+	consumerConf.RequestTimeout = c.marshal.cluster.options.ConsumeRequestTimeout
 	// Do not retry. If we get back no data, we'll do our own retries.
 	consumerConf.RetryLimit = 0
 	kafkaConsumer, err := c.marshal.cluster.broker.Consumer(consumerConf)

--- a/marshal/marshal.go
+++ b/marshal/marshal.go
@@ -57,7 +57,7 @@ type Marshaler struct {
 // creating multiple marshalers in your program, you should instead call Dial and then use
 // the NewMarshaler method on that object.
 func NewMarshaler(clientID, groupID string, brokers []string) (*Marshaler, error) {
-	cluster, err := Dial("automatic", brokers)
+	cluster, err := Dial("automatic", brokers, NewMarshalOptions())
 	if err != nil {
 		return nil, err
 	}

--- a/marshal/rationalizer.go
+++ b/marshal/rationalizer.go
@@ -71,7 +71,7 @@ func (c *KafkaCluster) consumeFromKafka(partID int, out chan message, startOldes
 	// Assume we're starting at the oldest offset for consumption
 	consumerConf := kafka.NewConsumerConf(MarshalTopic, int32(partID))
 	consumerConf.StartOffset = kafka.StartOffsetOldest
-	consumerConf.RequestTimeout = 1 * time.Second
+	consumerConf.RequestTimeout = c.options.MarshalRequestTimeout
 
 	// Get the offsets of this partition, we're going to arbitrarily pick something that
 	// is ~100,000 from the end if there's more than that. This is only if startOldest is


### PR DESCRIPTION
This allows passing in options to the cluster dialer used for advanced
use cases. This can be used to configure under the hood how many of
various resources Marshal uses as well as certain timeouts.

These can be used if you need to change behaviors, although we recommend
carefully testing any changes you make so as to avoid any adverse
affects.