### PR TITLE
Reacquired dropped partitions

### DIFF
--- a/marshal/marshal_test.go
+++ b/marshal/marshal_test.go
@@ -80,28 +80,28 @@ func (s *MarshalSuite) TestClaimPartitionIntegration(c *C) {
 	select {
 	case out := <-resp:
 		c.Assert(out, Equals, true)
-	case <-time.After(2 * time.Second):
+	case <-time.After(5 * time.Second):
 		c.Error("Timed out claiming partition")
 	}
 
 	select {
 	case out := <-resp:
 		c.Assert(out, Equals, true)
-	case <-time.After(2 * time.Second):
+	case <-time.After(5 * time.Second):
 		c.Error("Timed out claiming partition")
 	}
 
 	select {
 	case out := <-resp:
 		c.Assert(out, Equals, false)
-	case <-time.After(2 * time.Second):
+	case <-time.After(5 * time.Second):
 		c.Error("Timed out claiming partition")
 	}
 
 	select {
 	case out := <-resp:
 		c.Assert(out, Equals, true)
-	case <-time.After(2 * time.Second):
+	case <-time.After(5 * time.Second):
 		c.Error("Timed out claiming partition")
 	}
 }

--- a/marshal/rationalizer.go
+++ b/marshal/rationalizer.go
@@ -170,6 +170,7 @@ func (c *KafkaCluster) updateClaim(msg *msgHeartbeat) {
 	topic.partitions[msg.PartID].GroupID = msg.GroupID
 	topic.partitions[msg.PartID].LastOffset = msg.LastOffset
 	topic.partitions[msg.PartID].LastHeartbeat = int64(msg.Time)
+	topic.partitions[msg.PartID].LastRelease = 0
 }
 
 // releaseClaim is called whenever someone has released their claim on a partition.
@@ -191,6 +192,7 @@ func (c *KafkaCluster) releaseClaim(msg *msgReleasingPartition) {
 	// which means this is no longer claimed
 	topic.partitions[msg.PartID].LastOffset = msg.LastOffset
 	topic.partitions[msg.PartID].LastHeartbeat = 0
+	topic.partitions[msg.PartID].LastRelease = int64(msg.Time)
 }
 
 // handleClaim is called whenever we see a ClaimPartition message.
@@ -222,6 +224,7 @@ func (c *KafkaCluster) handleClaim(msg *msgClaimingPartition) {
 	topic.partitions[msg.PartID].GroupID = msg.GroupID
 	topic.partitions[msg.PartID].LastOffset = 0 // not present in this message, reset.
 	topic.partitions[msg.PartID].LastHeartbeat = int64(msg.Time)
+	topic.partitions[msg.PartID].LastRelease = 0
 }
 
 // rationalize is a goroutine that constantly consumes from a given partition of the marshal

--- a/marshal/rationalizer_test.go
+++ b/marshal/rationalizer_test.go
@@ -218,6 +218,8 @@ func (s *RationalizerSuite) TestReleaseClaim(c *C) {
 	// Now they release it at position 10
 	s.out <- releasingPartition(30, "cl", "gr", "test1", 0, 10)
 	c.Assert(s.m.cluster.waitForRsteps(3), Equals, 3)
+	c.Assert(s.m.GetLastPartitionClaim("test1", 0).LastHeartbeat, Equals, int64(0))
+	c.Assert(s.m.GetLastPartitionClaim("test1", 0).LastRelease, Equals, int64(30))
 
 	// They released at 30, should be free as of 31
 	s.m.cluster.ts = 31

--- a/marshal/topic.go
+++ b/marshal/topic.go
@@ -77,6 +77,7 @@ type PartitionOffsets struct {
 
 // PartitionClaim contains claim information about a given partition.
 type PartitionClaim struct {
+	LastRelease   int64
 	LastHeartbeat int64
 	LastOffset    int64
 	ClientID      string


### PR DESCRIPTION
Right now Marshal will drop partitions if they're unhealthy and then
never reacquire them. This leads to degenerate cases where people who
run single clients end up losing partitions and never reclaiming them
sometimes which can be unfortunate.

The desired goal of this behavior is to ensure we don't just get back
into an unhealthy state immediately after releasing something. This adds
a cooldown on the process so we can reacquire a partition eventually
but not until a heartbeat interval has passed. In the steady state
with multiple consumers running Marshal, unhealthy partitions that get
released will just get snapped up by other consumers quickly (within a
few seconds).

This diff should remove one of the major cases where Marshal users get
confused and angsty about the system.