### PR TITLE
Add ReleaseGroup message

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -54,7 +54,10 @@ The protocol is defined with several simple messages:
    **partition**, **last_offset** and is used when a consumer wants to proactively release
    a partition.
 1. `ClaimingMessages` which includes **client_id**, **group_id**, **topic**,
-   **partition**, proposed_last_offset is used for the At Most Once consumption flow.
+   **partition**, **proposed_last_offset** is used for the At Most Once consumption flow.
+1. `ReleaseGroup` which includes **client_id**, **group_id**, **msg_expire_time**. This message
+   is sent by a special Admin actor, which can pause an entire consumer group identified
+   by the **group_id**, until **msg_expire_time**.
 
 ## Determining World State
 

--- a/marshal/marshal.go
+++ b/marshal/marshal.go
@@ -246,6 +246,7 @@ func (m *Marshaler) GetPartitionOffsets(topicName string, partID int) (Partition
 // msgBase constructs a base message object for a message.
 func (m *Marshaler) msgBase(topicName string, partID int) *msgBase {
 	return &msgBase{
+		Version:    1,
 		Time:       int(time.Now().Unix()),
 		InstanceID: m.instanceID,
 		ClientID:   m.clientID,

--- a/marshal/message.go
+++ b/marshal/message.go
@@ -45,6 +45,10 @@ const (
 	msgTypeClaimingMessages    msgType = 3
 	msgLengthClaimingMessages  int     = msgLengthBase + 1
 	idxCMProposedCurrentOffset int     = idxBaseEnd + 1
+
+	msgTypeReleaseGroup   msgType = 4
+	msgLengthReleaseGroup int     = msgLengthBase + 1
+	idxRGMsgExpireTime    int     = idxBaseEnd + 1
 )
 
 type message interface {
@@ -118,6 +122,16 @@ func decode(inp []byte) (message, error) {
 			return nil, fmt.Errorf("Invalid message (cm offset): [%s]", string(inp))
 		}
 		return &msgClaimingMessages{msgBase: base, ProposedCurrentOffset: offset}, nil
+	case "ReleaseGroup":
+		if len(parts) != msgLengthReleaseGroup {
+			return nil, fmt.Errorf("Invalid message (rg length): [%s]", string(inp))
+		}
+		expiry, err := strconv.Atoi(parts[idxRGMsgExpireTime])
+		if err != nil {
+			return nil, fmt.Errorf("Invalid message (rg message expire time): [%s]", string(inp))
+		}
+
+		return &msgReleaseGroup{msgBase: base, MsgExpireTime: expiry}, nil
 	}
 	return nil, fmt.Errorf("Invalid message: [%s]", string(inp))
 }
@@ -231,5 +245,27 @@ func (m *msgClaimingMessages) Type() msgType {
 
 // Timestamp returns the timestamp of the message
 func (m *msgClaimingMessages) Timestamp() int {
+	return m.Time
+}
+
+// msgReleaseGroup is used by the Admin to pause a consumer group,
+// identified by groupID, until MsgExpireTime.
+type msgReleaseGroup struct {
+	msgBase
+	MsgExpireTime int
+}
+
+// Encode returns a string representation of the message.
+func (m *msgReleaseGroup) Encode() string {
+	return "ReleaseGroup/" + m.msgBase.Encode() + fmt.Sprintf("/%d", m.MsgExpireTime)
+}
+
+// Type returns the type of this message.
+func (m *msgReleaseGroup) Type() msgType {
+	return msgTypeReleaseGroup
+}
+
+// Timestamp returns the timestamp of the message
+func (m *msgReleaseGroup) Timestamp() int {
 	return m.Time
 }

--- a/marshal/message_test.go
+++ b/marshal/message_test.go
@@ -40,6 +40,13 @@ func (s *MessageSuite) TestMessageEncode(c *C) {
 		ProposedCurrentOffset: 9,
 	}
 	c.Assert(cm.Encode(), Equals, "ClaimingMessages/4/2/ii/cl/gr/t/3/9")
+
+	rg := msgReleaseGroup{
+		// Base message GroupID identifies which consumer group to release.
+		msgBase:       base,
+		MsgExpireTime: 12,
+	}
+	c.Assert(rg.Encode(), Equals, "ReleaseGroup/4/2/ii/cl/gr/t/3/12")
 }
 
 func (s *MessageSuite) TestMessageDecode(c *C) {
@@ -65,7 +72,7 @@ func (s *MessageSuite) TestMessageDecode(c *C) {
 	mcp, ok := msg.(*msgClaimingPartition)
 	if !ok || msg.Type() != msgTypeClaimingPartition || mcp.ClientID != "cl" ||
 		mcp.GroupID != "gr" || mcp.Topic != "t" || mcp.PartID != 1 || mcp.Time != 2 ||
-		mhb.Version != 4 {
+		mcp.Version != 4 {
 		c.Error("ClaimingPartition message contents invalid")
 	}
 
@@ -89,5 +96,16 @@ func (s *MessageSuite) TestMessageDecode(c *C) {
 		mcm.Topic != "t" || mcm.PartID != 1 || mcm.ProposedCurrentOffset != 2 || mcm.Time != 2 ||
 		mhb.Version != 4 {
 		c.Error("ClaimingMessages message contents invalid")
+	}
+
+	msg, err = decode([]byte("ReleaseGroup/4/2/ii/cl/gr/t/1/12"))
+	if msg == nil || err != nil {
+		c.Error("Expected msg, got error", err)
+	}
+	mrg, ok := msg.(*msgReleaseGroup)
+	if !ok || msg.Type() != msgTypeReleaseGroup || mrg.ClientID != "cl" || mrg.GroupID != "gr" ||
+		mrg.Topic != "t" || mrg.PartID != 1 || mrg.MsgExpireTime != 12 || mrg.Time != 2 ||
+		mrg.Version != 4 {
+		c.Error("ReleaseGroup message contents invalid")
 	}
 }


### PR DESCRIPTION
Adds new ReleaseGroup message, to be sent by an Admin struct to pause an entire consumer group.

Wasn't sure about the groupID semantics: I consider the groupID in baseMsg to be that of the consumer group being stopped. Should I add another field to the message?