### PR TITLE
New Admin struct and consumer paused state behavior

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -57,7 +57,8 @@ The protocol is defined with several simple messages:
    **partition**, **proposed_last_offset** is used for the At Most Once consumption flow.
 1. `ReleaseGroup` which includes **client_id**, **group_id**, **msg_expire_time**. This message
    is sent by a special Admin actor, which can pause an entire consumer group identified
-   by the **group_id**, until **msg_expire_time**.
+   by the **group_id**, until **msg_expire_time**. This message is used to set a consumer
+   group's position. See the section "Setting Consumer Group Position."
 
 ## Determining World State
 
@@ -181,6 +182,10 @@ to claim that partition, starting that whole process.
 In the ALO consumption case, this can lead to two consumers running on a single batch
 of messages at the same time, but it is constrained to one batch. The AMO consumer cannot
 have that failure case, at worst it will never process some messages.
+
+## Setting Consumer Group Position
+
+Documentation being written.
 
 # TODO
 

--- a/marshal/admin.go
+++ b/marshal/admin.go
@@ -1,0 +1,340 @@
+/*
+ * portal - marshal
+ *
+ * a library that implements an algorithm for doing consumer coordination within Kafka, rather
+ * than using Zookeeper or another external system.
+ *
+ */
+
+package marshal
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/dropbox/kafka/proto"
+)
+
+// Admins will wait a total of consumerReleaseClaimWaitTime
+// for paused consumers to release their claims on partitions.
+const (
+	consumerReleaseClaimWaitSleep = time.Duration(5 * time.Second)
+	consumerReleaseClaimWaitTime  = 15 * time.Minute
+)
+
+// Admin is used to pause a consumer group and set what position it reads from
+// for certain partitions.
+type Admin interface {
+	// SetConsumerGroupPosition resets consumers to read starting from
+	// offsets on each topic, partition pair in positions.
+	SetConsumerGroupPosition(groupID string, offsets map[string]map[int]int64) error
+}
+
+type consumerGroupAdmin struct {
+	clientID     string
+	groupID      string
+	marshaler    *Marshaler
+	pauseTimeout time.Duration
+
+	// claimHealth is 0 if any of our successfully-claimed claims fail to heartbeat.
+	claimHealth *int32
+	// The lock protects the structs below.
+	lock *sync.RWMutex
+	// claims are partitions that we've successfully claimed after they've been released,
+	// that we'd like to reset the offsets for.
+	claims []claimAttempt
+	// releaseGroupPartitions keeps track of which Marshal partitions
+	// we've produced ReleaseGroup  messages to.
+	releaseGroupPartitions []int32
+}
+
+// claimAttempt represents a topic, partition we'd like to reset the offset of.
+type claimAttempt struct {
+	topic  string
+	partID int
+	// What we'd like to set the offset of a particular partition to be.
+	newOffset int64
+	// What the current offset of a particular partition is.
+	currentOffset int64
+}
+
+// addClaimAttempt adds a successfully-claimed partition to our Admin.
+func (a *consumerGroupAdmin) addClaimAttempt(topic string,
+	partID int, currentOffset, newOffset int64) {
+
+	a.lock.Lock()
+	defer a.lock.Unlock()
+
+	c := claimAttempt{
+		topic:         topic,
+		partID:        partID,
+		newOffset:     newOffset,
+		currentOffset: currentOffset}
+	a.claims = append(a.claims, c)
+}
+
+// claimHealth returns whether or not any of the admin's claims have failed to heartbeat.
+func (a *consumerGroupAdmin) claimsHealthy() bool {
+	return atomic.LoadInt32(a.claimHealth) == 0
+}
+
+// NewAdmin returns a new Admin struct bound to a Marshaler. The Marshaler should not have
+// any consumers associated with it.
+func (m *Marshaler) NewAdmin(groupID string, pauseTimeout time.Duration) (Admin, error) {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+
+	if len(m.consumers) != 0 {
+		return nil, fmt.Errorf(
+			"The Marshaler instance bound to an Admin should not have any consumers.")
+	}
+	return &consumerGroupAdmin{
+		clientID:     m.clientID,
+		groupID:      groupID,
+		marshaler:    m,
+		pauseTimeout: pauseTimeout,
+
+		claimHealth: new(int32),
+		lock:        &sync.RWMutex{},
+	}, nil
+}
+
+// release releases an Admin's claim on a partition. Optionally resets the offset on the partition.
+func (a consumerGroupAdmin) release(topic string, partID int, offset int64) bool {
+	if err := a.marshaler.ReleasePartition(topic, partID, offset); err != nil {
+		log.Errorf("[%s:%d] Admin failed to release partition with offset %d: %s",
+			topic, partID, offset, err)
+		return false
+	}
+
+	return true
+}
+
+// releaseClaims releases all claims the Admin has, optionally resetting their offsets.
+func (a *consumerGroupAdmin) releaseClaims(resetOffset bool) error {
+	a.lock.RLock()
+	defer a.lock.RUnlock()
+
+	if !resetOffset {
+		log.Infof("Admin releasing claims without resetting offsets.")
+	}
+
+	fail := make(chan bool)
+	defer close(fail)
+	var wg sync.WaitGroup
+	for _, claim := range a.claims {
+		wg.Add(1)
+
+		releaseOffset := claim.currentOffset
+		if resetOffset {
+			releaseOffset = claim.newOffset
+		}
+
+		go func(t string, p int, offset int64) {
+			if ok := a.release(t, p, offset); !ok {
+				fail <- true
+			}
+			wg.Done()
+		}(claim.topic, claim.partID, releaseOffset)
+	}
+
+	// Wait on all workers to reset their respective Kafka offset.
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-fail:
+		return fmt.Errorf("Admin failed to reset Kafka offset!")
+	case <-done:
+		return nil
+	}
+}
+
+// heartbeatLoop hearbeats as if we had a claim to this partition and were simply
+// not reading past where the previous owner had left off.
+func (a *consumerGroupAdmin) heartbeatLoop(
+	topic string, partID int, lastOffset int64, stopChan chan struct{}) {
+
+	for {
+		select {
+		// Stop claimHealth either when all topic, partitions have been successfully claimed,
+		// or the Admin has failed to do so and needs to abort.
+		case <-stopChan:
+			return
+		default:
+			// If we fail to heartbeat, record this in claimHealth.
+			// The Admin will take care of cleaning up other claims.
+			if err := a.marshaler.Heartbeat(topic, partID, lastOffset); err != nil {
+				log.Errorf("[%s:%d] Admin failed to heartbeat. It is now unhealthy "+
+					"and will not reset offsets.", topic, partID)
+				atomic.StoreInt32(a.claimHealth, 0)
+				return
+			}
+			time.Sleep(<-a.marshaler.cluster.jitters)
+		}
+	}
+}
+
+// claimAndHeartbeat attempts to claim a partition released by a paused consumer.
+// It heartbeats the previous offset.
+func (a *consumerGroupAdmin) claimAndHeartbeat(topic string,
+	partID int, newOffset int64, stopHeartbeat chan struct{}) bool {
+
+	// Get current offsets, which we will try to keep claimHealth.
+	partitionClaim := a.marshaler.GetLastPartitionClaim(topic, partID)
+
+	// Next, try to claim the partition.
+	if !a.marshaler.ClaimPartition(topic, partID) {
+		log.Errorf("[%s:%d] Admin couldn't claim partition to set Kafka offset",
+			topic, partID)
+		return false
+	}
+
+	// Continuously heartbeat the last offsets.
+	a.addClaimAttempt(topic, partID, partitionClaim.CurrentOffset, newOffset)
+	go a.heartbeatLoop(topic, partID, partitionClaim.CurrentOffset, stopHeartbeat)
+	return true
+}
+
+// constructReleaseGroupMessage returns a ReleaseGroup message to write to the Marshal topic.
+func (a *consumerGroupAdmin) constructReleaseGroupMessage() *msgReleaseGroup {
+	now := time.Now()
+	base := &msgBase{
+		Time:       int(now.Unix()),
+		InstanceID: a.marshaler.instanceID,
+		ClientID:   a.clientID,
+		GroupID:    a.groupID,
+	}
+	return &msgReleaseGroup{
+		msgBase:       *base,
+		MsgExpireTime: int(now.Add(a.pauseTimeout).Unix()),
+	}
+}
+
+// sendReleaseGroupMessage sends a ReleaseGroup message for a consumer group reading froma given topic.
+func (a *consumerGroupAdmin) sendReleaseGroupMessage(topicName string, partID int) error {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+	topic := a.marshaler.cluster.getPartitionState(a.groupID, topicName, partID)
+
+	for _, partition := range a.releaseGroupPartitions {
+		if int32(topic.claimPartition) == partition {
+			return nil
+		}
+	}
+
+	a.releaseGroupPartitions = append(a.releaseGroupPartitions, int32(topic.claimPartition))
+	rg := a.constructReleaseGroupMessage()
+	_, err := a.marshaler.cluster.producer.Produce(MarshalTopic,
+		int32(topic.claimPartition), &proto.Message{Value: []byte(rg.Encode())})
+	return err
+}
+
+// pauseGroupAndWaitForRelease is called for every partition we'd like to change the offset for.
+// It first sends a ReleaseGroup message to Marshal, then waits for it to be released,
+// then attempts to claim it.
+func (a *consumerGroupAdmin) pauseGroupAndWaitForRelease(topicName string, partID int) bool {
+	if err := a.sendReleaseGroupMessage(topicName, partID); err != nil {
+		log.Errorf("[%s:%d] Admin failed to produce ReleaseMessage group to Kafka: %s",
+			topicName, partID, err)
+		return false
+	}
+
+	// Wait for the paused consumer to release its claim.
+	tick := time.NewTicker(consumerReleaseClaimWaitSleep)
+	defer tick.Stop()
+
+	select {
+	case <-tick.C:
+		if cl := a.marshaler.GetPartitionClaim(topicName, partID); cl.LastHeartbeat == 0 {
+			break
+		}
+	case <-time.After(consumerReleaseClaimWaitTime):
+		return false
+	}
+	return true
+}
+
+// SetConsumerGroupPosition sets where the consumer group identified by groupID
+// should start reading from for given partitions.
+func (a *consumerGroupAdmin) SetConsumerGroupPosition(groupID string,
+	offsets map[string]map[int]int64) error {
+
+	log.Infof("Admin %s going to pause consumer group %s", a.clientID, groupID)
+	var wg sync.WaitGroup
+	// Send out a ReleaseGroup message to Marshal for each partition we want to set the position for,
+	// then wait for all the partitions to be released.
+	fail := make(chan bool)
+	defer close(fail)
+	for topicName, partitionOffsets := range offsets {
+		for partID, _ := range partitionOffsets {
+			wg.Add(1)
+			go func(topicName string, partID int) {
+				if ok := a.pauseGroupAndWaitForRelease(topicName, partID); !ok {
+					fail <- true
+				}
+				wg.Done()
+			}(topicName, partID)
+		}
+	}
+
+	// Wait on all partitions to be released, or one failure.
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-fail:
+		return fmt.Errorf("Consumer group %s has not been reset", groupID)
+	case <-done:
+		break
+	}
+
+	// Attempt to claim the now-released partitions, then heartbeat old offsets after a successful claim.
+	log.Infof("Admin now claiming released partitions.")
+	claimFailures := make(chan bool)
+	defer close(claimFailures)
+
+	var claimsWg sync.WaitGroup
+	// stopHeartbeating channel instructs all successfully claimed and heartbeating claims to stop.
+	stopHeartbeating := make(chan struct{})
+	for topicName, partitionOffsets := range offsets {
+		for partID, offset := range partitionOffsets {
+			claimsWg.Add(1)
+
+			go func(topicName string, partID int, offset int64) {
+				if ok := a.claimAndHeartbeat(topicName, partID, offset, stopHeartbeating); !ok {
+					claimFailures <- true
+				}
+				claimsWg.Done()
+			}(topicName, partID, offset)
+		}
+	}
+
+	// Wait on attempts to claim partitions.
+	claimsDone := make(chan struct{})
+	go func() {
+		claimsWg.Wait()
+		close(claimsDone)
+	}()
+
+	select {
+	case <-claimFailures:
+		log.Errorf("Couldn't claim a partition -- admin failed to reset consumer group position! " +
+			"Now releasing all existing claims without resetting offsets.")
+		close(stopHeartbeating)
+		return a.releaseClaims(false)
+	case <-claimsDone:
+		close(stopHeartbeating)
+		// Release claims and reset offsets, if all claims have been successfully heartbeating.
+		// If not, we'll release claims and not reset offsets.
+		return a.releaseClaims(a.claimsHealthy())
+	}
+}

--- a/marshal/admin_test.go
+++ b/marshal/admin_test.go
@@ -1,0 +1,109 @@
+package marshal
+
+import (
+	"fmt"
+	. "gopkg.in/check.v1"
+	"time"
+
+	"github.com/dropbox/kafka/kafkatest"
+	"github.com/dropbox/kafka/proto"
+)
+
+var _ = Suite(&AdminSuite{})
+
+type AdminSuite struct {
+	c      *C
+	s      *kafkatest.Server
+	m      *Marshaler
+	mAdmin *Marshaler
+	a      Admin
+}
+
+func (s *AdminSuite) SetUpTest(c *C) {
+	s.c = c
+	s.s = StartServer()
+
+	// Use Dial to create multiple Marshalers - one for the consumer, one for the admin.
+	brokers := []string{s.s.Addr()}
+	cluster, err := Dial("automatic", brokers, NewMarshalOptions())
+	c.Assert(err, IsNil)
+	s.m, err = cluster.NewMarshaler("cl-w-admin", "gr-w-admin")
+	c.Assert(err, IsNil)
+	s.mAdmin, err = cluster.NewMarshaler("cl-admin", "gr-w-admin")
+	c.Assert(err, IsNil)
+
+	// Create an Admin that sets a pause duration of 15 seconds.
+	s.a, err = s.mAdmin.NewAdmin("gr-w-admin", 15*time.Second)
+	c.Assert(err, IsNil)
+}
+
+func (s *AdminSuite) TearDownTest(c *C) {
+	s.m.Terminate()
+	s.s.Close()
+}
+
+func (s *AdminSuite) Produce(topicName string, partID int, msgs ...string) int64 {
+	var protos []*proto.Message
+	for _, msg := range msgs {
+		protos = append(protos, &proto.Message{Value: []byte(msg)})
+	}
+	offset, err := s.m.cluster.producer.Produce(topicName, int32(partID), protos...)
+	s.c.Assert(err, IsNil)
+	return offset
+}
+
+// Tests rewinding the position a consumer group reads from.
+func (s *AdminSuite) TestRewindConsumer(c *C) {
+	// Rewind to after the first produced message for one partition.
+	rewindOffsets := make(map[string]map[int]int64)
+	rewindOffsets["test1"] = make(map[int]int64)
+	rewindOffsets["test1"][0] = 0
+
+	// Messages that we will try to reconsume after resetting the offset.
+	messages := []string{"aren't", "data", "races", "fun"}
+	s.Produce("test1", 0, messages...)
+
+	// Set up a consumer and have it claim the only partition for this topic.
+	cns := NewTestConsumer(s.m, []string{"test1"})
+	s.m.addNewConsumer(cns)
+	defer cns.Terminate(true)
+
+	c.Assert(cns.GetCurrentLoad(), Equals, 0)
+	cns.claimPartitions()
+	go cns.manageClaims()
+	c.Assert(cns.GetCurrentLoad(), Equals, 1)
+
+	for i := 0; i < len(messages); i++ {
+		msg := cns.consumeOne()
+		c.Assert(msg.Value, DeepEquals, []byte(messages[i]))
+		fmt.Printf("%s, %d [%s:%d]\n", msg.Value, msg.Offset, msg.Topic, msg.Partition)
+	}
+
+	// Flush to commit offsets immediately, so that we can check them.
+	c.Assert(cns.Flush(), IsNil)
+	offsets, err := s.m.GetPartitionOffsets("test1", 0)
+	c.Assert(err, IsNil)
+	c.Assert(offsets.Committed, Equals, int64(4))
+
+	// Rewind the consumer group to re-consume.
+	err = s.a.SetConsumerGroupPosition(s.m.groupID, rewindOffsets)
+	c.Assert(err, IsNil)
+
+	offsets, err = s.m.GetPartitionOffsets("test1", 0)
+	c.Assert(err, IsNil)
+	c.Assert(offsets.Current, Equals, int64(0))
+	c.Assert(offsets.Committed, Equals, int64(0))
+
+	// This is janky, but we'll have to wait until the consumer unpauses itself
+	// and picks up the claim once again.
+	for s.m.cluster.IsGroupPaused(s.m.GroupID()) {
+		fmt.Println("Group still paused, sleeping...")
+		time.Sleep(1 * time.Second)
+	}
+	// See if the consumer can consume again.
+	for i := 0; i < len(messages); i++ {
+		msg := cns.consumeOne()
+		c.Assert(msg.Value, DeepEquals, []byte(messages[i]))
+		fmt.Printf("%s, %d [%s:%d]\n", msg.Value, msg.Offset, msg.Topic, msg.Partition)
+	}
+}

--- a/marshal/consumer.go
+++ b/marshal/consumer.go
@@ -188,9 +188,16 @@ func (m *Marshaler) NewConsumer(topicNames []string, options ConsumerOptions) (*
 						}
 					}
 
-					c.claims[topic][partID] = newClaim(
+					// Attempt to claim, this can fail
+					claim := newClaim(
 						topic, partID, c.marshal, c, c.messages, options)
-					c.sendTopicClaimsUpdate()
+					if claim == nil {
+						log.Warningf("[%s:%d] failed to fast-reclaim", topic, partID)
+					} else {
+						c.claims[topic][partID] = claim
+						go claim.healthCheckLoop()
+						c.sendTopicClaimsUpdate()
+					}
 				}
 			}
 
@@ -360,6 +367,24 @@ func (c *Consumer) rndIntn(n int) int {
 	defer c.lock.Unlock()
 
 	return c.rand.Intn(n)
+}
+
+// releaseClaims releases all claims this consumer has. This is called when a consumer is paused.
+func (c *Consumer) releaseClaims() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	// Release all claims that this consumer keeps track of and remove them from the claims map.
+	for topic, partitions := range c.claims {
+		for partID, claim := range partitions {
+			if claim.Claimed() {
+				log.Warningf("[%s:%d] Consumer still paused, releasing claim",
+					topic, partID)
+				claim.Release()
+			}
+		}
+		c.claims[topic] = make(map[int]*claim)
+	}
 }
 
 // claimPartitions actually attempts to claim partitions. If the current consumer is
@@ -589,7 +614,7 @@ func (c *Consumer) sendTopicClaimsLoop() {
 	}
 }
 
-// updatePartitionCounts pulls the latest partition counts per topic from the Marshaler
+// updatePartitionCounts pulls the latest partition counts per topic from the Marshaler.
 func (c *Consumer) updatePartitionCounts() {
 	// Write lock as we're updating c.partitions below, potentially
 	c.lock.Lock()
@@ -609,14 +634,18 @@ func (c *Consumer) manageClaims() {
 	for !c.Terminated() {
 		c.updatePartitionCounts()
 
-		// Attempt to claim more partitions, this always runs and will keep running until all
-		// partitions in the topic are claimed (by somebody).
-		if c.options.ClaimEntireTopic {
-			c.claimTopics()
+		// If we learn that our consumer group is paused, release all claims.
+		if c.marshal.cluster.IsGroupPaused(c.marshal.GroupID()) {
+			c.releaseClaims()
 		} else {
-			c.claimPartitions()
+			// Attempt to claim more partitions, this always runs and will keep running until all
+			// partitions in the topic are claimed (by somebody).
+			if c.options.ClaimEntireTopic {
+				c.claimTopics()
+			} else {
+				c.claimPartitions()
+			}
 		}
-
 		// Now sleep a bit so we don't pound things
 		// TODO: Raise this later, we shouldn't attempt to claim this fast, this is just for
 		// development.

--- a/marshal/consumer_test.go
+++ b/marshal/consumer_test.go
@@ -24,7 +24,7 @@ type ConsumerSuite struct {
 	cn *Consumer
 }
 
-func (s *ConsumerSuite) NewTestConsumer(m *Marshaler, topics []string) *Consumer {
+func NewTestConsumer(m *Marshaler, topics []string) *Consumer {
 	cn := &Consumer{
 		alive:              new(int32),
 		marshal:            m,
@@ -58,7 +58,7 @@ func (s *ConsumerSuite) SetUpTest(c *C) {
 	s.m2, err = NewMarshaler("cl2", "gr", []string{s.s.Addr()})
 	c.Assert(err, IsNil)
 
-	s.cn = s.NewTestConsumer(s.m, []string{"test16"})
+	s.cn = NewTestConsumer(s.m, []string{"test16"})
 }
 
 func (s *ConsumerSuite) TearDownTest(c *C) {
@@ -212,13 +212,13 @@ func (s *ConsumerSuite) TestTopicClaim(c *C) {
 func (s *ConsumerSuite) TestTopicClaimBlocked(c *C) {
 	topic := "test2"
 	// Claim partition 0 with one consumer
-	cnbl := s.NewTestConsumer(s.m, []string{topic})
+	cnbl := NewTestConsumer(s.m, []string{topic})
 	c.Assert(cnbl.tryClaimPartition(topic, 0), Equals, true)
 	c.Assert(s.m.cluster.waitForRsteps(2), Equals, 2)
 	c.Assert(s.m2.cluster.waitForRsteps(2), Equals, 2)
 
 	// Claim an entire topic, this creates a real consumer
-	cn := s.NewTestConsumer(s.m2, []string{topic})
+	cn := NewTestConsumer(s.m2, []string{topic})
 	cn.lock.Lock()
 	cn.options.ClaimEntireTopic = true
 	cn.lock.Unlock()
@@ -279,13 +279,13 @@ func (s *ConsumerSuite) TestTopicClaimBlocked(c *C) {
 func (s *ConsumerSuite) TestTopicClaimPartial(c *C) {
 	topic := "test2"
 	// Claim partition 1 with one consumer
-	cnbl := s.NewTestConsumer(s.m, []string{topic})
+	cnbl := NewTestConsumer(s.m, []string{topic})
 	c.Assert(cnbl.tryClaimPartition(topic, 1), Equals, true)
 	c.Assert(s.m.cluster.waitForRsteps(2), Equals, 2)
 	c.Assert(s.m2.cluster.waitForRsteps(2), Equals, 2)
 
 	// Claim an entire topic, this creates a real consumer
-	cn := s.NewTestConsumer(s.m2, []string{topic})
+	cn := NewTestConsumer(s.m2, []string{topic})
 	cn.lock.Lock()
 	cn.options.ClaimEntireTopic = true
 	cn.lock.Unlock()
@@ -328,7 +328,7 @@ func (s *ConsumerSuite) TestTopicClaimPartial(c *C) {
 func (s *ConsumerSuite) TestMultiTopicClaim(c *C) {
 	// Claim partition 1 with one consumer
 	topics := []string{"test1", "test2", "test16"}
-	cn := s.NewTestConsumer(s.m, topics)
+	cn := NewTestConsumer(s.m, topics)
 	cn.lock.Lock()
 	cn.options.ClaimEntireTopic = true
 	cn.lock.Unlock()
@@ -387,7 +387,7 @@ func (s *ConsumerSuite) TestMultiTopicClaim(c *C) {
 func (s *ConsumerSuite) TestMultiTopicClaimWithLimit(c *C) {
 	// Claim partition 1 with one consumer
 	topics := []string{"test1", "test2", "test16"}
-	cn := s.NewTestConsumer(s.m, topics)
+	cn := NewTestConsumer(s.m, topics)
 	cn.lock.Lock()
 	cn.options.ClaimEntireTopic = true
 	cn.options.MaximumClaims = 2
@@ -634,7 +634,7 @@ func (s *ConsumerSuite) TestBalancedClaim(c *C) {
 }
 
 func (s *ConsumerSuite) TestUnhealthyReclaim(c *C) {
-	cn := s.NewTestConsumer(s.m, []string{"test1"})
+	cn := NewTestConsumer(s.m, []string{"test1"})
 	defer cn.Terminate(true)
 
 	// Claim a partition
@@ -751,7 +751,7 @@ func (s *ConsumerSuite) TestMaximumGreedyClaims(c *C) {
 func (s *ConsumerSuite) TestUpdatePartitionCounts(c *C) {
 	// Create a new consumer on test1
 	topic := "test1"
-	cn := s.NewTestConsumer(s.m, []string{topic})
+	cn := NewTestConsumer(s.m, []string{topic})
 	defer cn.Terminate(true)
 	s.cn = cn
 

--- a/marshal/message.go
+++ b/marshal/message.go
@@ -126,6 +126,9 @@ func decode(inp []byte) (message, error) {
 		if len(parts) != msgLengthReleaseGroup {
 			return nil, fmt.Errorf("Invalid message (rg length): [%s]", string(inp))
 		}
+		if base.Topic != "" || base.PartID != 0 {
+			return nil, fmt.Errorf("Invalid ReleaseGroup message (Topic, PartID must be empty)")
+		}
 		expiry, err := strconv.Atoi(parts[idxRGMsgExpireTime])
 		if err != nil {
 			return nil, fmt.Errorf("Invalid message (rg message expire time): [%s]", string(inp))
@@ -257,6 +260,9 @@ type msgReleaseGroup struct {
 
 // Encode returns a string representation of the message.
 func (m *msgReleaseGroup) Encode() string {
+	if m.msgBase.Topic != "" || m.msgBase.PartID != 0 {
+		panic("ReleaseGroup message must have non-empty topic and partition id.")
+	}
 	return "ReleaseGroup/" + m.msgBase.Encode() + fmt.Sprintf("/%d", m.MsgExpireTime)
 }
 

--- a/marshal/message_test.go
+++ b/marshal/message_test.go
@@ -41,12 +41,15 @@ func (s *MessageSuite) TestMessageEncode(c *C) {
 	}
 	c.Assert(cm.Encode(), Equals, "ClaimingMessages/4/2/ii/cl/gr/t/3/9")
 
+	rgBase := base
+	rgBase.Topic = ""
+	rgBase.PartID = 0
 	rg := msgReleaseGroup{
 		// Base message GroupID identifies which consumer group to release.
-		msgBase:       base,
+		msgBase:       rgBase,
 		MsgExpireTime: 12,
 	}
-	c.Assert(rg.Encode(), Equals, "ReleaseGroup/4/2/ii/cl/gr/t/3/12")
+	c.Assert(rg.Encode(), Equals, "ReleaseGroup/4/2/ii/cl/gr//0/12")
 }
 
 func (s *MessageSuite) TestMessageDecode(c *C) {
@@ -98,13 +101,13 @@ func (s *MessageSuite) TestMessageDecode(c *C) {
 		c.Error("ClaimingMessages message contents invalid")
 	}
 
-	msg, err = decode([]byte("ReleaseGroup/4/2/ii/cl/gr/t/1/12"))
+	msg, err = decode([]byte("ReleaseGroup/4/2/ii/cl/gr//0/12"))
 	if msg == nil || err != nil {
 		c.Error("Expected msg, got error", err)
 	}
 	mrg, ok := msg.(*msgReleaseGroup)
 	if !ok || msg.Type() != msgTypeReleaseGroup || mrg.ClientID != "cl" || mrg.GroupID != "gr" ||
-		mrg.Topic != "t" || mrg.PartID != 1 || mrg.MsgExpireTime != 12 || mrg.Time != 2 ||
+		mrg.Topic != "" || mrg.PartID != 0 || mrg.MsgExpireTime != 12 || mrg.Time != 2 ||
 		mrg.Version != 4 {
 		c.Error("ReleaseGroup message contents invalid")
 	}


### PR DESCRIPTION
WIP. Sorry this is a lot -- wanted to get thoughts/feedback. I was wondering if I should make better use of chans and return an error with the particular topic:partition that fails. Should we work in a global timeout for SetConsumerGroupPosition?