### PR TITLE
Fix data race

### DIFF
--- a/marshal/consumer.go
+++ b/marshal/consumer.go
@@ -639,8 +639,9 @@ func (c *Consumer) terminateAndCleanup(release bool, remove bool) bool {
 
 	latestTopicClaims := make(map[string]bool)
 	releasedTopics := make(map[string]bool)
-	c.lock.RLock()
-	defer c.lock.RUnlock()
+
+	c.lock.Lock()
+	defer c.lock.Unlock()
 
 	for topic, topicClaims := range c.claims {
 		for partID, claim := range topicClaims {

--- a/marshal/marshal.go
+++ b/marshal/marshal.go
@@ -89,6 +89,7 @@ func (m *Marshaler) addNewConsumer(c *Consumer) {
 func (m *Marshaler) removeConsumer(c *Consumer) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
+
 	for i, cn := range m.consumers {
 		if cn == c {
 			m.consumers = append(m.consumers[:i], m.consumers[i+1:]...)


### PR DESCRIPTION
We only held the read lock for some reason. This function is closing
channels which is a write operation, so we need to ensure we have the
full write lock before doing so.