### PR TITLE
Fix refactor problem

### DIFF
--- a/marshal/consumer.go
+++ b/marshal/consumer.go
@@ -190,6 +190,7 @@ func (m *Marshaler) NewConsumer(topicNames []string, options ConsumerOptions) (*
 
 					c.claims[topic][partID] = newClaim(
 						topic, partID, c.marshal, c, c.messages, options)
+					go c.claims[topic][partID].healthCheckLoop()
 					c.sendTopicClaimsUpdate()
 				}
 			}


### PR DESCRIPTION
To make tests more reliable I made health check loop not start
automatically when the claim starts. It's now the reponsibility of the
consumer to start the health check loop. I forgot to make fast reclaims
start the loop, leading to an issue where 2 minutes after startup we
would see that the claim has gone away and would attempt to claim it
again, thereby double-claiming and failing.

This fixes the 2 minute crash but it still shouldn't be double-claiming
something it already "knows" it has. Next diff.