### PR TITLE
Fix issue with pv=0 health checks

### DIFF
--- a/marshal/claim.go
+++ b/marshal/claim.go
@@ -507,7 +507,7 @@ func (c *claim) healthCheck() bool {
 	// If the consumer is moving as fast or faster than the partition and the consumer is
 	// at least moving, consider it healthy. This case is true in the standard catching
 	// up from behind case.
-	if partitionVelocity < consumerVelocity || (partitionVelocity <= 0 && consumerVelocity > 0) {
+	if partitionVelocity < consumerVelocity {
 		log.Infof("[%s:%d] consumer catching up: consume ∆ %0.2f >= produce ∆ %0.2f",
 			c.topic, c.partID, consumerVelocity, partitionVelocity)
 		c.cyclesBehind = 0

--- a/marshal/claim.go
+++ b/marshal/claim.go
@@ -501,9 +501,13 @@ func (c *claim) healthCheck() bool {
 		return true
 	}
 
-	// If the consumer is moving faster than the partition, consider it healthy. This case
-	// is true in the standard catching up from behind case.
-	if partitionVelocity <= consumerVelocity {
+	// At this point we know the consumer is NOT PRESENTLY caught up or predicted to catch
+	// up in the next two heartbeats.
+
+	// If the consumer is moving as fast or faster than the partition and the consumer is
+	// at least moving, consider it healthy. This case is true in the standard catching
+	// up from behind case.
+	if partitionVelocity < consumerVelocity || (partitionVelocity <= 0 && consumerVelocity > 0) {
 		log.Infof("[%s:%d] consumer catching up: consume ∆ %0.2f >= produce ∆ %0.2f",
 			c.topic, c.partID, consumerVelocity, partitionVelocity)
 		c.cyclesBehind = 0

--- a/marshal/claim_test.go
+++ b/marshal/claim_test.go
@@ -554,6 +554,28 @@ func (s *ClaimSuite) TestHealthCheck(c *C) {
 	c.Assert(s.cl.healthCheck(), Equals, true)
 	c.Assert(s.cl.cyclesBehind, Equals, 0)
 
+	// Test that PV=0, CV=0 but behind is unhealthy
+	s.cl.offsets.Current = 21
+	s.cl.offsetCurrentHistory = [10]int64{21, 21, 21, 21, 21, 21, 21, 21, 21, 21}
+	s.cl.offsets.Latest = 23
+	s.cl.offsetLatestHistory = [10]int64{23, 23, 23, 23, 23, 23, 23, 23, 23, 23}
+	c.Assert(s.cl.ConsumerVelocity(), Equals, float64(0))
+	c.Assert(s.cl.PartitionVelocity(), Equals, float64(0))
+	c.Assert(s.cl.ConsumerVelocity() == s.cl.PartitionVelocity(), Equals, true)
+	c.Assert(s.cl.healthCheck(), Equals, true)
+	c.Assert(s.cl.cyclesBehind, Equals, 1)
+	c.Assert(s.cl.healthCheck(), Equals, true)
+	c.Assert(s.cl.cyclesBehind, Equals, 2)
+
+	// Now we advance one message, giving us SOME velocity -- even tho PV is still 0
+	// this should make us healthy
+	s.cl.offsets.Current = 22
+	s.cl.offsetCurrentHistory = [10]int64{21, 21, 21, 21, 21, 21, 21, 21, 21, 22}
+	c.Assert(s.cl.PartitionVelocity(), Equals, float64(0))
+	c.Assert(s.cl.ConsumerVelocity() > s.cl.PartitionVelocity(), Equals, true)
+	c.Assert(s.cl.healthCheck(), Equals, true)
+	c.Assert(s.cl.cyclesBehind, Equals, 0)
+
 	// Now we're behind and fail health checks 3 times, this will release
 	s.cl.offsets.Latest = 32
 	s.cl.offsetLatestHistory = [10]int64{1, 11, 21, 32, 0, 0, 0, 0, 0, 0}
@@ -567,7 +589,7 @@ func (s *ClaimSuite) TestHealthCheck(c *C) {
 	c.Assert(s.m.cluster.waitForRsteps(3), Equals, 3)
 	c.Assert(s.m.GetPartitionClaim("test16", 0).LastHeartbeat, Equals, int64(0))
 	c.Assert(s.m.GetPartitionClaim("test16", 0).CurrentOffset, Equals, int64(0))
-	c.Assert(s.m.GetLastPartitionClaim("test16", 0).CurrentOffset, Equals, int64(21))
+	c.Assert(s.m.GetLastPartitionClaim("test16", 0).CurrentOffset, Equals, int64(22))
 
 	// If we are okay with CV<PV we shouldn't release
 	opts := NewConsumerOptions()


### PR DESCRIPTION
In the case where producers stop writing to a partition, the "partition
velocity" would drop to 0. This basically enabled consumers to always be
healthy -- even if they would stop consuming while behind. Instead, we
would expect a stalled consumer to become unhealthy if they can't catch
up -- even if the producers aren't writing.