### PR TITLE
Fixes a few issues

### DIFF
--- a/marshal/cluster.go
+++ b/marshal/cluster.go
@@ -301,6 +301,7 @@ func (c *KafkaCluster) getTopicPartitions(topicName string) int {
 func (c *KafkaCluster) removeMarshal(m *Marshaler) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
+
 	for i, ml := range c.marshalers {
 		if ml == m {
 			c.marshalers = append(c.marshalers[:i], c.marshalers[i+1:]...)
@@ -335,6 +336,7 @@ func (c *KafkaCluster) pauseConsumerGroup(groupID string, adminID string, expiry
 func (c *KafkaCluster) IsGroupPaused(groupID string) bool {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
+
 	if res, ok := c.pausedGroups[groupID]; !ok {
 		return false
 	} else {
@@ -358,8 +360,8 @@ func (c *KafkaCluster) Terminate() {
 	}
 	c.marshalers = nil
 
-	// Close the broker!
-	c.broker.Close()
+	// Close the broker asynchronously to prevent blocking on potential network I/O
+	go c.broker.Close()
 }
 
 // Terminated returns whether or not we have been terminated.

--- a/marshal/message.go
+++ b/marshal/message.go
@@ -55,6 +55,7 @@ type message interface {
 	Encode() string
 	Timestamp() int
 	Type() msgType
+	Ownership() (string, string, string)
 }
 
 // decode takes a slice of bytes that should constitute a single message and attempts to
@@ -165,6 +166,11 @@ func (m *msgBase) Timestamp() int {
 	return m.Time
 }
 
+// Ownership returns InstanceID, ClientID, GroupID for message
+func (m *msgBase) Ownership() (string, string, string) {
+	return m.InstanceID, m.ClientID, m.GroupID
+}
+
 // msgHeartbeat is sent regularly by all consumers to re-up their claim to the partition that
 // they're consuming.
 type msgHeartbeat struct {
@@ -187,6 +193,11 @@ func (m *msgHeartbeat) Timestamp() int {
 	return m.Time
 }
 
+// Ownership returns InstanceID, ClientID, GroupID for message
+func (m *msgHeartbeat) Ownership() (string, string, string) {
+	return m.InstanceID, m.ClientID, m.GroupID
+}
+
 // msgClaimingPartition is used in the claim flow.
 type msgClaimingPartition struct {
 	msgBase
@@ -205,6 +216,11 @@ func (m *msgClaimingPartition) Type() msgType {
 // Timestamp returns the timestamp of the message
 func (m *msgClaimingPartition) Timestamp() int {
 	return m.Time
+}
+
+// Ownership returns InstanceID, ClientID, GroupID for message
+func (m *msgClaimingPartition) Ownership() (string, string, string) {
+	return m.InstanceID, m.ClientID, m.GroupID
 }
 
 // msgReleasingPartition is used in a controlled shutdown to indicate that you are done with
@@ -229,6 +245,11 @@ func (m *msgReleasingPartition) Timestamp() int {
 	return m.Time
 }
 
+// Ownership returns InstanceID, ClientID, GroupID for message
+func (m *msgReleasingPartition) Ownership() (string, string, string) {
+	return m.InstanceID, m.ClientID, m.GroupID
+}
+
 // msgClaimingMessages is used for at-most-once consumption semantics, this is a pre-commit
 // advisory message.
 type msgClaimingMessages struct {
@@ -249,6 +270,11 @@ func (m *msgClaimingMessages) Type() msgType {
 // Timestamp returns the timestamp of the message
 func (m *msgClaimingMessages) Timestamp() int {
 	return m.Time
+}
+
+// Ownership returns InstanceID, ClientID, GroupID for message
+func (m *msgClaimingMessages) Ownership() (string, string, string) {
+	return m.InstanceID, m.ClientID, m.GroupID
 }
 
 // msgReleaseGroup is used by the Admin to pause a consumer group,
@@ -274,4 +300,9 @@ func (m *msgReleaseGroup) Type() msgType {
 // Timestamp returns the timestamp of the message
 func (m *msgReleaseGroup) Timestamp() int {
 	return m.Time
+}
+
+// Ownership returns InstanceID, ClientID, GroupID for message
+func (m *msgReleaseGroup) Ownership() (string, string, string) {
+	return m.InstanceID, m.ClientID, m.GroupID
 }


### PR DESCRIPTION
First, primarily, this fixes the internal double claim which was firing
in a racy manner. When we would be blocked on obtaining a lock long
enough that we saw the ClaimPartition message arrive, we could "detect"
an internal double-claim erroneously. This is now fixed via:

The claim object used to have this concept of 'Claimed' and 'Terminated'
which meant different things but it was subtle. The double-claim was
attempting to determine if we had two claim objects referencing the
same data but using the 'Claimed' state (which uses the rationalizer
global world state) is inherently racy since the world may change while
we're waiting on a lock. We've removed this notion of 'Claimed' from the
'claim' object (follow me?) because I assert:

* Asking a claim object if the thing it refers to is globally Claimed
doesn't make much sense because we are usually saying 'I would like
to perform some operation on you, may I?' and that's more properly a
reference to Terminated,

* A claim will self-Terminate during its normal heartbeat flow long
before Claimed will return false so it's a quicker indicator,

Therefore I believe that using Terminated instead of a mix is strictly
better from a performance perspective and leaves us open to fewer bugs,
plus it makes it very clear what you're asking a claim object about and
when you're asking the Marshaler for world-state information.

This diff also includes some cleanup (I got annoyed at the 'isFoo'
naming convention that was used in one place).