### PR TITLE
Update offsets before health check

### DIFF
--- a/marshal/claim.go
+++ b/marshal/claim.go
@@ -451,9 +451,6 @@ func (c *claim) healthCheck() bool {
 		return false
 	}
 
-	// Let's update current offset internally to the last processed
-	c.updateOffsets()
-
 	// Get velocities; these functions both use the locks so we have to do this before
 	// we personally take the lock (to avoid deadlock)
 	consumerVelocity := c.ConsumerVelocity()
@@ -532,6 +529,8 @@ func (c *claim) healthCheck() bool {
 func (c *claim) healthCheckLoop() {
 	time.Sleep(<-c.marshal.cluster.jitters)
 	for !c.Terminated() {
+		// Update current offsets internally to the last processed before checking if we are healthy
+		c.updateOffsets()
 		if c.healthCheck() {
 			go c.heartbeat()
 		}

--- a/marshal/claim.go
+++ b/marshal/claim.go
@@ -385,9 +385,6 @@ func (c *claim) heartbeat() bool {
 		return false
 	}
 
-	// Let's update current offset internally to the last processed
-	c.updateOffsets()
-
 	// Lock held because we use c.offsets and update c.lastHeartbeat below
 	c.lock.Lock()
 	defer c.lock.Unlock()
@@ -453,6 +450,9 @@ func (c *claim) healthCheck() bool {
 	if c.Terminated() {
 		return false
 	}
+
+	// Let's update current offset internally to the last processed
+	c.updateOffsets()
 
 	// Get velocities; these functions both use the locks so we have to do this before
 	// we personally take the lock (to avoid deadlock)

--- a/marshal/consumer_test.go
+++ b/marshal/consumer_test.go
@@ -66,6 +66,7 @@ func (s *ConsumerSuite) TearDownTest(c *C) {
 		s.cn.Terminate(true)
 	}
 	s.m.Terminate()
+	s.m2.Terminate()
 	s.s.Close()
 }
 
@@ -524,7 +525,8 @@ func (s *ConsumerSuite) TestCommittedOffset(c *C) {
 	// Since the committed offset was 2, the first consumption should be the third message
 	c.Assert(s.cn.consumeOne().Value, DeepEquals, []byte("m3"))
 
-	// Heartbeat should succeed and update the committed offset
+	// Heartbeat should succeed after updating the committed offset
+	c.Assert(cl.updateOffsets(), IsNil)
 	c.Assert(cl.heartbeat(), Equals, true)
 	c.Assert(s.m.cluster.waitForRsteps(3), Equals, 3)
 	offset, _, err := s.m.offsets.Offset("test16", 0)
@@ -567,6 +569,7 @@ func (s *ConsumerSuite) TestCommitByToken(c *C) {
 	c.Assert(cl.numTrackingOffsets(), Equals, 1)
 
 	// Now heartbeat, both 0
+	c.Assert(cl.updateOffsets(), IsNil)
 	c.Assert(cl.heartbeat(), Equals, true)
 	c.Assert(cl.outstandingMessages, Equals, 0)
 	c.Assert(cl.numTrackingOffsets(), Equals, 0)
@@ -675,6 +678,7 @@ func (s *ConsumerSuite) TestFastReclaim(c *C) {
 	c.Assert(cn1.consumeOne().Value, DeepEquals, []byte("m1"))
 	c.Assert(cn1.consumeOne().Value, DeepEquals, []byte("m2"))
 	cn1.lock.Lock()
+	c.Assert(cn1.claims["test2"][0].updateOffsets(), IsNil)
 	c.Assert(cn1.claims["test2"][0].heartbeat(), Equals, true)
 	cn1.lock.Unlock()
 	c.Assert(s.m.cluster.waitForRsteps(5), Equals, 5)


### PR DESCRIPTION
cc @zorkian 

Today we health check on the offsets as they were after the previous health check, which means that most clients get spurious warnings no matter how fast they consume. For example, observe that consume delta is reported as 0 twice even though we committed a few hundred offsets here:

```2016/09/28 15:53:07 [elided:6] consumer attempting to claim
2016/09/28 15:53:07 [elided:6] consumer fast-forwarding from 0 to 299624
2016/09/28 15:53:08 [elided:6] consumer elided claimed at offset 299624 (is 28055 behind)
2016/09/28 15:53:39 [elided:6] consumer too slow: consume ∆ 0.00 < produce ∆ 0.00 (warning #1)
2016/09/28 15:53:42 [elided:6] heartbeat: Current offset is 299624, partition offset range is 299624..327680.
2016/09/28 15:53:42 [elided:6] heartbeat: There are 10000 messages in queue and 618 messages outstanding.
2016/09/28 15:54:10 [elided:6] consumer too slow: consume ∆ 0.00 < produce ∆ 0.00 (warning #2)
2016/09/28 15:54:11 [elided:6] heartbeat: Current offset is 299701, partition offset range is 299624..327680.
2016/09/28 15:54:11 [elided:6] heartbeat: There are 10000 messages in queue and 1248 messages outstanding.
2016/09/28 15:54:55 [elided:6] consumer catching up: consume ∆ 77.00 >= produce ∆ 0.00
2016/09/28 15:54:57 [elided:6] heartbeat: Current offset is 300564, partition offset range is 299624..327682.
2016/09/28 15:54:57 [elided:6] heartbeat: There are 10000 messages in queue and 1226 messages outstanding.
2016/09/28 15:55:47 [elided:6] consumer catching up: consume ∆ 470.00 >= produce ∆ 1.00
2016/09/28 15:55:49 [elided:6] heartbeat: Current offset is 301611, partition offset range is 299624..327686.
2016/09/28 15:55:49 [elided:6] heartbeat: There are 10000 messages in queue and 1433 messages outstanding.
2016/09/28 15:56:43 [elided:6] consumer catching up: consume ∆ 662.33 >= produce ∆ 2.00
2016/09/28 15:56:43 [elided:6] heartbeat: Current offset is 302966, partition offset range is 299624..327688.
2016/09/28 15:56:43 [elided:6] heartbeat: There are 10000 messages in queue and 1580 messages outstanding.```

Most clients end up okay because they consume relatively rapidly, but this makes it very difficult for consumers to process small amounts of expensive messages because if they don't commit one before the first heartbeat they will lose the partition.

The old call chain was `healthCheckLoop` -> `healthcheck` (reads velocities), then `heartbeat` -> `updateOffsets` (updates velocities).

This diff makes the call chain `healthCheckLoop` -> `healthcheck` -> `updateOffsets` (updates velocities), then (reads velocities), then `heartbeat`.