### PR TITLE
Directly terminate consumer upon double-claim

### DIFF
--- a/marshal/consumer.go
+++ b/marshal/consumer.go
@@ -363,6 +363,7 @@ func (c *Consumer) tryClaimPartition(topic string, partID int) bool {
 				log.Errorf("This is a catastrophic error. We're terminating Marshal.")
 				log.Errorf("No further messages will be available. Please restart.")
 				go newClaim.Release()
+				go c.terminateAndCleanup(false, false)
 				go func() {
 					c.marshal.PrintState()
 					c.marshal.Terminate()


### PR DESCRIPTION
cc @zorkian 

Strictly speaking this diff ought to do nothing, but in practice it should make it so that calls to `Consumer::Terminated()` will return `true` after a double-claim, even if the call chain within `marshal.Terminate` deadlocks. This is important because it allows clients to poll `Terminated()` after a timeout on a read from the message channel to detect that Marshal is being shut down.

 I claim it is safe because the `CompareAndSwapInt32` check on `Consumer::terminateAndCleanup` prevents double-termination even if `Marshal::Terminate` goes on to call `Consumer::Terminate`.