### PR TITLE
Make all sync objects pointers.

### DIFF
--- a/marshal/admin.go
+++ b/marshal/admin.go
@@ -125,9 +125,8 @@ func (a *consumerGroupAdmin) releaseClaims(resetOffset bool) error {
 	fail := make(chan bool)
 	defer close(fail)
 	var wg sync.WaitGroup
+	wg.Add(len(a.claims))
 	for _, claim := range a.claims {
-		wg.Add(1)
-
 		releaseOffset := claim.currentOffset
 		if resetOffset {
 			releaseOffset = claim.newOffset

--- a/marshal/consumer.go
+++ b/marshal/consumer.go
@@ -107,7 +107,7 @@ type Consumer struct {
 	topicClaimsUpdated chan struct{}
 
 	// lock protects access to the following mutables.
-	lock       sync.RWMutex
+	lock       *sync.RWMutex
 	rand       *rand.Rand
 	partitions map[string]int
 	claims     map[string]map[int]*claim
@@ -141,6 +141,7 @@ func (m *Marshaler) NewConsumer(topicNames []string, options ConsumerOptions) (*
 		partitions:         partitions,
 		options:            options,
 		messages:           make(chan *Message, 10000),
+		lock:               &sync.RWMutex{},
 		rand:               rand.New(rand.NewSource(time.Now().UnixNano())),
 		claims:             make(map[string]map[int]*claim),
 		topicClaimsChan:    make(chan map[string]bool),

--- a/marshal/consumer_test.go
+++ b/marshal/consumer_test.go
@@ -31,6 +31,7 @@ func NewTestConsumer(m *Marshaler, topics []string) *Consumer {
 		topics:             topics,
 		options:            NewConsumerOptions(),
 		partitions:         make(map[string]int),
+		lock:               &sync.RWMutex{},
 		rand:               rand.New(rand.NewSource(time.Now().UnixNano())),
 		claims:             make(map[string]map[int]*claim),
 		messages:           make(chan *Message, 1000),

--- a/marshal/marshal.go
+++ b/marshal/marshal.go
@@ -47,7 +47,7 @@ type Marshaler struct {
 
 	// Lock protects the following members; you must have this lock in order to
 	// read from or write to these.
-	lock      sync.RWMutex
+	lock      *sync.RWMutex
 	consumers []*Consumer
 }
 

--- a/marshal/rationalizer_test.go
+++ b/marshal/rationalizer_test.go
@@ -1,6 +1,7 @@
 package marshal
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -56,11 +57,14 @@ func NewWorld() *Marshaler {
 		clientID: "cl",
 		groupID:  "gr",
 		cluster: &KafkaCluster{
-			quit:       new(int32),
-			rsteps:     new(int32),
-			groups:     make(map[string]map[string]*topicState),
-			partitions: 1,
+			quit:          new(int32),
+			rsteps:        new(int32),
+			groups:        make(map[string]map[string]*topicState),
+			partitions:    1,
+			lock:          &sync.RWMutex{},
+			rationalizers: &sync.WaitGroup{},
 		},
+		lock: &sync.RWMutex{},
 	}
 }
 

--- a/marshal/topic.go
+++ b/marshal/topic.go
@@ -20,7 +20,7 @@ type topicState struct {
 	claimPartition int
 
 	// This lock also protects the contents of the partitions member.
-	lock       sync.RWMutex
+	lock       *sync.RWMutex
 	partitions []PartitionClaim
 }
 


### PR DESCRIPTION
cc @zorkian 

Could do passes to verify we never use locks in any non-pointer receiver methods, but long term the only way to be safe is to always use pointers.

Also a small tweak to the admin WaitGroup usage to remove a race.