### PR TITLE
Remove two locks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,16 @@
 language: go
 
 go:
-  - 1.6
   - 1.5
+  - 1.7
 
 env:
   - "PATH=/home/travis/gopath/bin:$PATH"
+
 script:
-  - go get -u github.com/golang/lint/golint
-  - golint ./...
+  - cd marshal
   - test `gofmt -l . | wc -l` = 0
-  - go test -race ./...
+  - go test -p=1 -race -timeout=600s -check.v ./...
 
 install:
   - go get -v -t ./...
-
-matrix:
-    allow_failures:
-        - go: 1.6

--- a/README.md
+++ b/README.md
@@ -158,14 +158,10 @@ heartbeat interval) will be reprocessed by the next consumer.
 ### Message Ordering
 
 Kafka guarantees the ordering of messages committed to a partition,
-but does not guarantee any ordering across partitions. Marshal *can*
-give you the same guarantees, but by default we make no guarantee about
-message ordering whatsoever.
-
-If ordering is important, set the `StrictOrdering` option when you
-create your consumer. This option will (possibly drastically) reduce the
-speed of consumption, however, since only a single uncommitted message
-(per partition) can be in-flight at a time.
+but does not guarantee any ordering across partitions. Marshal will
+give you messages from any partition it has claimed, so in essence,
+Marshal *does not* guarantee ordering. If you need message ordering,
+this library is not presently appropriate for you.
 
 If you are having throughput problems you should increase the number of
 partitions you have available so that Marshal can have more in-flight

--- a/example/main.go
+++ b/example/main.go
@@ -45,8 +45,7 @@ func main() {
 	msgChan := consumer.ConsumeChannel()
 
 	// You can spin up many goroutines to process messages; how many depends entirely on the type
-	// of workload you have. Note that if you turn StrictOrdering on, spinning up multiple
-	// routines may not help as much as you expect. See the docs.
+	// of workload you have. See the docs.
 	for i := 0; i < 10; i++ {
 		i := i
 		go func() {

--- a/marshal/admin.go
+++ b/marshal/admin.go
@@ -272,7 +272,7 @@ func (a *consumerGroupAdmin) SetConsumerGroupPosition(groupID string,
 	fail := make(chan bool)
 	defer close(fail)
 	for topicName, partitionOffsets := range offsets {
-		for partID, _ := range partitionOffsets {
+		for partID := range partitionOffsets {
 			wg.Add(1)
 			go func(topicName string, partID int) {
 				if ok := a.pauseGroupAndWaitForRelease(topicName, partID); !ok {

--- a/marshal/admin_test.go
+++ b/marshal/admin_test.go
@@ -1,7 +1,6 @@
 package marshal
 
 import (
-	"fmt"
 	. "gopkg.in/check.v1"
 	"time"
 
@@ -20,6 +19,8 @@ type AdminSuite struct {
 }
 
 func (s *AdminSuite) SetUpTest(c *C) {
+	ResetTestLogger(c)
+
 	s.c = c
 	s.s = StartServer()
 
@@ -76,7 +77,6 @@ func (s *AdminSuite) TestRewindConsumer(c *C) {
 	for i := 0; i < len(messages); i++ {
 		msg := cns.consumeOne()
 		c.Assert(msg.Value, DeepEquals, []byte(messages[i]))
-		fmt.Printf("%s, %d [%s:%d]\n", msg.Value, msg.Offset, msg.Topic, msg.Partition)
 	}
 
 	// Flush to commit offsets immediately, so that we can check them.
@@ -97,13 +97,13 @@ func (s *AdminSuite) TestRewindConsumer(c *C) {
 	// This is janky, but we'll have to wait until the consumer unpauses itself
 	// and picks up the claim once again.
 	for s.m.cluster.IsGroupPaused(s.m.GroupID()) {
-		fmt.Println("Group still paused, sleeping...")
+		log.Infof("Group still paused, sleeping...")
 		time.Sleep(1 * time.Second)
 	}
 	// See if the consumer can consume again.
 	for i := 0; i < len(messages); i++ {
 		msg := cns.consumeOne()
 		c.Assert(msg.Value, DeepEquals, []byte(messages[i]))
-		fmt.Printf("%s, %d [%s:%d]\n", msg.Value, msg.Offset, msg.Topic, msg.Partition)
+		log.Infof("%s, %d [%s:%d]\n", msg.Value, msg.Offset, msg.Topic, msg.Partition)
 	}
 }

--- a/marshal/cluster.go
+++ b/marshal/cluster.go
@@ -102,6 +102,7 @@ func Dial(name string, brokers []string, options MarshalOptions) (*KafkaCluster,
 	brokerConf := kafka.NewBrokerConf("PortalMarshal")
 	brokerConf.MetadataRefreshFrequency = time.Hour
 	brokerConf.ConnectionLimit = options.BrokerConnectionLimit
+	brokerConf.LeaderRetryLimit = 1 // Do not retry
 	broker, err := kafka.Dial(brokers, brokerConf)
 	if err != nil {
 		return nil, err
@@ -400,6 +401,8 @@ func (c *KafkaCluster) Terminate() {
 	if !atomic.CompareAndSwapInt32(c.quit, 0, 1) {
 		return
 	}
+
+	log.Infof("[%s] beginning termination", c.name)
 
 	c.lock.Lock()
 	defer c.lock.Unlock()

--- a/marshal/cluster_test.go
+++ b/marshal/cluster_test.go
@@ -15,6 +15,8 @@ type ClusterSuite struct {
 }
 
 func (s *ClusterSuite) SetUpTest(c *C) {
+	ResetTestLogger(c)
+
 	s.s = StartServer()
 
 	var err error

--- a/marshal/consumer.go
+++ b/marshal/consumer.go
@@ -65,12 +65,6 @@ type ConsumerOptions struct {
 	// Defaults to false/off.
 	GreedyClaims bool
 
-	// StrictOrdering tells the consumer that only a single message per partition
-	// is allowed to be in-flight at a time. In order to consume the next message
-	// you must commit the existing message. This option has a strong penalty to
-	// consumption parallelism.
-	StrictOrdering bool
-
 	// ReleaseClaimsIfBehind indicates whether to release a claim if a consumer
 	// is consuming at a rate slower than the partition is being produced to.
 	ReleaseClaimsIfBehind bool
@@ -228,7 +222,6 @@ func NewConsumerOptions() ConsumerOptions {
 		FastReclaim:           true,
 		ClaimEntireTopic:      false,
 		GreedyClaims:          false,
-		StrictOrdering:        false,
 		ReleaseClaimsIfBehind: true,
 	}
 }
@@ -505,18 +498,18 @@ func (c *Consumer) claimTopics() {
 
 	// Get a copy of c.partitions so we don't have to hold the lock throughout
 	// this entire method
-	topic_partitions := make(map[string]int)
+	topicPartitions := make(map[string]int)
 	func() {
 		c.lock.RLock()
 		defer c.lock.RUnlock()
 
 		for k, v := range c.partitions {
-			topic_partitions[k] = v
+			topicPartitions[k] = v
 		}
 	}()
 
 	// Now iterate each and try to claim
-	for topic, partitions := range topic_partitions {
+	for topic, partitions := range topicPartitions {
 		if partitions <= 0 {
 			continue
 		}
@@ -533,14 +526,14 @@ func (c *Consumer) claimTopics() {
 			}
 		} else {
 			// Unclaimed, so attempt to claim partition 0. This is how we key topic claims.
-			log.Infof("[%s] attempting to claim topic (key partition 0)\n", topic)
+			log.Infof("[%s] attempting to claim topic (key partition 0)", topic)
+
 			// we need to check if we're above the maximum topics to be claimed
 			// we should only allow the first k topics to be claimed and allow all
 			// of their partitions to be claimed. This is controlled by controlling how
 			// many (key partition 0) we claim.
-
 			if c.isTopicClaimLimitReached(topic) {
-				log.Infof("blocked claiming topic: %s due to limit %d\n",
+				log.Debugf("[%s] blocked claiming topic due to limit: %d",
 					topic, c.options.MaximumClaims)
 				continue
 			}
@@ -548,7 +541,7 @@ func (c *Consumer) claimTopics() {
 			if !c.tryClaimPartition(topic, 0) {
 				continue
 			}
-			log.Infof("[%s] claimed topic (key partition 0) successfully\n", topic)
+			log.Infof("[%s] claimed topic (key partition 0) successfully", topic)
 
 			// Optimistically send update to try to reduce latency between us claiming a
 			// topic and notifying a listener
@@ -559,7 +552,7 @@ func (c *Consumer) claimTopics() {
 		// through all partitions and attempt to claim any that we don't own yet.
 		for partID := 1; partID < partitions; partID++ {
 			if !c.marshal.Claimed(topic, partID) {
-				log.Infof("[%s:%d] claiming partition (topic claim mode)\n", topic, partID)
+				log.Infof("[%s:%d] claiming partition (topic claim mode)", topic, partID)
 				c.tryClaimPartition(topic, partID)
 			}
 		}
@@ -607,7 +600,7 @@ func (c *Consumer) sendTopicClaimsLoop() {
 				anyUpdates = true
 			}
 		}
-		for topic, _ := range claims {
+		for topic := range claims {
 			if _, ok := lastClaims[topic]; !ok {
 				// New topic claim
 				anyUpdates = true
@@ -754,7 +747,7 @@ func (c *Consumer) GetCurrentTopicClaims() (map[string]bool, error) {
 
 	// Iterate each topic we know about and see if we have partition 0 claimed
 	// for that topic, if so, consider it valid
-	for topic, _ := range c.partitions {
+	for topic := range c.partitions {
 		cl := c.marshal.GetPartitionClaim(topic, 0)
 		if cl.ClientID == c.marshal.ClientID() &&
 			cl.GroupID == c.marshal.GroupID() {
@@ -865,8 +858,8 @@ func (c *Consumer) Flush() error {
 	defer c.lock.RUnlock()
 
 	claims := make([]*claim, 0)
-	for topic, _ := range c.claims {
-		for partID, _ := range c.claims[topic] {
+	for topic := range c.claims {
+		for partID := range c.claims[topic] {
 			claims = append(claims, c.claims[topic][partID])
 		}
 	}

--- a/marshal/log.go
+++ b/marshal/log.go
@@ -10,52 +10,30 @@
 package marshal
 
 import (
-	"fmt"
-	"strings"
+	"sync"
 
 	"github.com/op/go-logging"
 )
 
-// optiopayLoggerShim is a translation layer between what the optiopay library expects and what
-// we provide so all the logging ends up in one nice place.
-type optiopayLoggerShim struct {
-	l *logging.Logger
-}
-
-// toString is because of the formatting that the optiopay library uses, this condenses it to a
-// version that works with our logging.
-func (l *optiopayLoggerShim) toString(msg string, args ...interface{}) string {
-	if len(args)%2 != 0 {
-		return fmt.Sprintf("%s: <count mismatch!> %s", msg, args)
-	}
-
-	var argset []string
-	for idx := 0; idx < len(args)/2; idx++ {
-		argset = append(argset, fmt.Sprintf("%v=%v", args[idx*2], args[idx*2+1]))
-	}
-
-	return fmt.Sprintf("%s: %s", msg, strings.Join(argset, ", "))
-}
-
-func (l *optiopayLoggerShim) Error(format string, args ...interface{}) {
-	l.l.Errorf(l.toString(format, args...))
-}
-
-func (l *optiopayLoggerShim) Warn(format string, args ...interface{}) {
-	l.l.Warningf(l.toString(format, args...))
-}
-
-func (l *optiopayLoggerShim) Info(format string, args ...interface{}) {
-	l.l.Infof(l.toString(format, args...))
-}
-
-func (l *optiopayLoggerShim) Debug(format string, args ...interface{}) {
-	l.l.Debugf(l.toString(format, args...))
-}
-
 var log *logging.Logger
+var logMu = &sync.Mutex{}
 
 func init() {
+	logMu.Lock()
+	defer logMu.Unlock()
+
+	if log != nil {
+		return
+	}
 	log = logging.MustGetLogger("KafkaMarshal")
 	logging.SetLevel(logging.INFO, "KafkaMarshal")
+}
+
+// SetLogger can be called with a logging.Logger in order to overwrite our internal
+// logger. Useful if you need to control the logging (such as in tests).
+func SetLogger(l *logging.Logger) {
+	logMu.Lock()
+	defer logMu.Unlock()
+
+	log = l
 }

--- a/marshal/log_test.go
+++ b/marshal/log_test.go
@@ -1,0 +1,53 @@
+package marshal
+
+import (
+	"sync"
+
+	"github.com/dropbox/kafka"
+	"github.com/dropbox/kafka/kafkatest"
+	"github.com/op/go-logging"
+
+	. "gopkg.in/check.v1"
+)
+
+type logTestBackend struct {
+	c  *C
+	mu *sync.Mutex
+}
+
+var logTest = &logTestBackend{mu: &sync.Mutex{}}
+
+func init() {
+	logMu.Lock()
+	defer logMu.Unlock()
+
+	leveledLogger := logging.AddModuleLevel(logTest)
+	leveledLogger.SetLevel(logging.DEBUG, "KafkaMarshal")
+	leveledLogger.SetLevel(logging.DEBUG, "KafkaClient")
+	leveledLogger.SetLevel(logging.DEBUG, "KafkaTest")
+
+	log = logging.MustGetLogger("KafkaMarshal")
+	log.SetBackend(leveledLogger)
+
+	kafkatest.SetLogger(log)
+	kafka.SetLogger(log)
+}
+
+func (l *logTestBackend) SetC(c *C) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.c = c
+}
+
+func ResetTestLogger(c *C) {
+	logTest.SetC(c)
+}
+
+func (l *logTestBackend) Log(lvl logging.Level, cd int, rec *logging.Record) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.c.Log(rec.Formatted(cd))
+	return nil
+}

--- a/marshal/marshal_test.go
+++ b/marshal/marshal_test.go
@@ -16,6 +16,8 @@ type MarshalSuite struct {
 }
 
 func (s *MarshalSuite) SetUpTest(c *C) {
+	ResetTestLogger(c)
+
 	s.s = StartServer()
 
 	var err error
@@ -42,7 +44,7 @@ func StartServer() *kafkatest.Server {
 	MakeTopic(srv, MarshalTopic, 4)
 	MakeTopic(srv, "test1", 1)
 	MakeTopic(srv, "test2", 2)
-	MakeTopic(srv, "test16", 16)
+	MakeTopic(srv, "test3", 3)
 	return srv
 }
 
@@ -51,14 +53,14 @@ func (s *MarshalSuite) TestNewMarshaler(c *C) {
 	c.Assert(s.m.Partitions(MarshalTopic), Equals, 4)
 	c.Assert(s.m.Partitions("test1"), Equals, 1)
 	c.Assert(s.m.Partitions("test2"), Equals, 2)
-	c.Assert(s.m.Partitions("test16"), Equals, 16)
+	c.Assert(s.m.Partitions("test3"), Equals, 3)
 	c.Assert(s.m.Partitions("unknown"), Equals, 0)
 
 	// If our hash algorithm changes, these values will have to change. This tests the low
 	// level hash function.
 	c.Assert(s.m.cluster.getClaimPartition("test1"), Equals, 2)
 	c.Assert(s.m.cluster.getClaimPartition("test2"), Equals, 1)
-	c.Assert(s.m.cluster.getClaimPartition("test16"), Equals, 0)
+	c.Assert(s.m.cluster.getClaimPartition("test3"), Equals, 2)
 	c.Assert(s.m.cluster.getClaimPartition("unknown"), Equals, 1)
 	c.Assert(s.m.cluster.getClaimPartition("unknown"), Equals, 1) // Twice on purpose.
 }

--- a/marshal/message_test.go
+++ b/marshal/message_test.go
@@ -6,6 +6,10 @@ var _ = Suite(&MessageSuite{})
 
 type MessageSuite struct{}
 
+func (s *MessageSuite) SetUpTest(c *C) {
+	ResetTestLogger(c)
+}
+
 func (s *MessageSuite) TestMessageEncode(c *C) {
 	base := msgBase{
 		Version:    4,

--- a/marshal/rationalizer.go
+++ b/marshal/rationalizer.go
@@ -70,6 +70,7 @@ func (c *KafkaCluster) consumeFromKafka(partID int, out chan message, startOldes
 
 	// Assume we're starting at the oldest offset for consumption
 	consumerConf := kafka.NewConsumerConf(MarshalTopic, int32(partID))
+	consumerConf.RetryErrLimit = 1 // Do not retry
 	consumerConf.StartOffset = kafka.StartOffsetOldest
 	consumerConf.RequestTimeout = c.options.MarshalRequestTimeout
 

--- a/marshal/rationalizer_test.go
+++ b/marshal/rationalizer_test.go
@@ -26,6 +26,8 @@ type RationalizerSuite struct {
 }
 
 func (s *RationalizerSuite) SetUpTest(c *C) {
+	ResetTestLogger(c)
+
 	s.m = NewWorld()
 	s.out = make(chan message)
 	go s.m.cluster.rationalize(0, s.out)


### PR DESCRIPTION
In two places (including teardown) we require the read lock just to get the current offset -- which we were just twiddling in the function we just called. Now that function returns the offset and we can immediately just use it.