### PR TITLE
Self-defense against pump issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,15 @@
 language: go
-
 go:
   - 1.5
   - 1.7
 
 env:
-  - "PATH=/home/travis/gopath/bin:$PATH"
+  - GOMAXPROCS=4
+
+sudo: false
 
 script:
   - cd marshal
   - test `gofmt -l . | wc -l` = 0
   - go test -p=1 -race -timeout=600s -check.v ./...
 
-install:
-  - go get -v -t ./...

--- a/marshal/cluster.go
+++ b/marshal/cluster.go
@@ -145,11 +145,13 @@ func Dial(name string, brokers []string, options MarshalOptions) (*KafkaCluster,
 	}
 
 	// A jitter calculator, just fills a channel with random numbers so that other
-	// people don't have to build their own random generator...
+	// people don't have to build their own random generator. It is important that
+	// these values be somewhat less than the HeartbeatInterval as we use this for
+	// jittering our heartbeats.
 	go func() {
 		rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
 		for {
-			jitter := rnd.Intn(HeartbeatInterval/2) + (HeartbeatInterval / 2)
+			jitter := rnd.Intn(HeartbeatInterval/2) + (HeartbeatInterval / 4)
 			c.jitters <- time.Duration(jitter) * time.Second
 		}
 	}()

--- a/marshal/rationalizer.go
+++ b/marshal/rationalizer.go
@@ -182,11 +182,11 @@ func (c *KafkaCluster) releaseClaim(msg *msgReleasingPartition) {
 	topic.lock.Lock()
 	defer topic.lock.Unlock()
 
-	log.Infof("[%s:%d] Client %s releasing", msg.Topic, msg.PartID, msg.ClientID)
 	// The partition must be claimed by the person releasing it
 	if !topic.partitions[msg.PartID].checkOwnership(msg, true) {
-		log.Warningf("[%s] ReleasePartition message from client that doesn't own it. Dropping.",
-			c.name)
+		log.Warningf(
+			"[%s] ReleasePartition %s:%d from client %s that doesn't own it. Dropping.",
+			c.name, msg.Topic, msg.PartID, msg.ClientID)
 		return
 	}
 


### PR DESCRIPTION
We've had reports of partitions wedging and making no forward progress.
This only seems to happen to people who have topic claim mode active,
but partition mode health checking may just be masking it.

This patch does two things:

* Watch the last time we saw a message. The health check loop will now
release partition claims if the consumer velocity hits 0 and we are not
caught up. This is true even in topic claim mode.

* This also fixes a (potential) issue where updateOffsets is failing
on calling PartitionOffsets (a Kafka call). In that mode, we'd never
updateCurrentOffsets and the heartbeat loop would continue happily. If
this was happening I'd have expected log entries, but let's make this
more failure-proof anyway by checking errors.