### PR TITLE
Three tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: go
 go:
-  - 1.5
   - 1.7
 
 env:

--- a/marshal/admin_test.go
+++ b/marshal/admin_test.go
@@ -34,7 +34,7 @@ func (s *AdminSuite) SetUpTest(c *C) {
 	s.mAdmin, err = cluster.NewMarshaler("cl-admin", "gr-w-admin")
 	c.Assert(err, IsNil)
 
-	// Create an Admin that sets a pause duration of 15 seconds.
+	// Create an Admin that sets a pause duration
 	s.a, err = s.mAdmin.NewAdmin("gr-w-admin", 15*time.Second)
 	c.Assert(err, IsNil)
 }
@@ -96,13 +96,17 @@ func (s *AdminSuite) TestRewindConsumer(c *C) {
 
 	// Flush to commit offsets immediately, so that we can check them.
 	c.Assert(cns.Flush(), IsNil)
+	c.Assert(s.m.cluster.waitForRsteps(6), Equals, 6)
 
 	// Both partitions should have been fully consumed and committed.
 	offsets, err := s.m.GetPartitionOffsets("test2", 0)
 	c.Assert(err, IsNil)
+	c.Assert(offsets.Current, Equals, int64(len(messages[0])))
 	c.Assert(offsets.Committed, Equals, int64(len(messages[0])))
+
 	offsets, err = s.m.GetPartitionOffsets("test2", 1)
 	c.Assert(err, IsNil)
+	c.Assert(offsets.Current, Equals, int64(len(messages[1])))
 	c.Assert(offsets.Committed, Equals, int64(len(messages[1])))
 
 	// Rewind the consumer group to re-consume.

--- a/marshal/cluster.go
+++ b/marshal/cluster.go
@@ -69,7 +69,7 @@ type MarshalOptions struct {
 	// data to us. Setting this high uses more connections and can lead to some latency
 	// but keeps the load on Kafka minimal. Use this to balance QPS against latency.
 	//
-	// Default: 100 milliseconds.
+	// Default: 1 millisecond.
 	ConsumeRequestTimeout time.Duration
 
 	// MarshalRequestTimeout is used for our coordination requests. This should be reasonable
@@ -91,17 +91,27 @@ type MarshalOptions struct {
 	// else you will end up with stalled streams. I.e., Kafka will never send you a message
 	// if the message is larger than this value but we can't detect that, we just think
 	// there is no data.
+	//
+	// Default: 2,000,000 bytes.
 	MaxMessageSize int32
+
+	// MaxMessageQueue is the number of messages to retrieve from Kafka and store in-memory
+	// waiting for consumption. This is per-Consumer and independent of message size so you
+	// should adjust this for your consumption patterns.
+	//
+	// Default: 1000 messages.
+	MaxMessageQueue int
 }
 
 // NewMarshalOptions returns a set of MarshalOptions populated with defaults.
 func NewMarshalOptions() MarshalOptions {
 	return MarshalOptions{
 		BrokerConnectionLimit:   30,
-		ConsumeRequestTimeout:   100 * time.Millisecond,
+		ConsumeRequestTimeout:   1 * time.Millisecond,
 		MarshalRequestTimeout:   1 * time.Millisecond,
 		MarshalRequestRetryWait: 500 * time.Millisecond,
 		MaxMessageSize:          2000000,
+		MaxMessageQueue:         1000,
 	}
 }
 

--- a/marshal/consumer.go
+++ b/marshal/consumer.go
@@ -134,7 +134,7 @@ func (m *Marshaler) NewConsumer(topicNames []string, options ConsumerOptions) (*
 		topics:             topicNames,
 		partitions:         partitions,
 		options:            options,
-		messages:           make(chan *Message, 10000),
+		messages:           make(chan *Message, m.cluster.options.MaxMessageQueue),
 		lock:               &sync.RWMutex{},
 		rand:               rand.New(rand.NewSource(time.Now().UnixNano())),
 		claims:             make(map[string]map[int]*claim),


### PR DESCRIPTION
Fix data race in closing: ensure we don't return from Terminate until
we've actually exited the messagePump.

Add maximum consumer queue size option.

Switch consume requests to block locally rather than on the Kafka end.
This will increase latency of messages in really slow partitions, but
will have no impact on busy partitions. This is to combat connections
being busy.