### PR TITLE
Fix a race in closing/using the channel

### DIFF
--- a/marshal/consumer_test.go
+++ b/marshal/consumer_test.go
@@ -39,6 +39,8 @@ func NewTestConsumer(m *Marshaler, topics []string) *Consumer {
 		messages:           make(chan *Message, 1000),
 		topicClaimsChan:    make(chan map[string]bool, 1),
 		topicClaimsUpdated: make(chan struct{}, 1),
+		stopChan:           make(chan struct{}),
+		doneChan:           make(chan struct{}),
 	}
 
 	for _, topic := range topics {


### PR DESCRIPTION
This makes the sendTopicClaimsUpdate method take an argument on whether
or not to close the channel after the message is sent. This is set false
everywhere except during termination where it's true. This avoids having
the close asynchronous to the write, which fixes the race.