### PR TITLE
Do not wipe offsets when rationalizing claims

### DIFF
--- a/marshal/rationalizer.go
+++ b/marshal/rationalizer.go
@@ -226,7 +226,6 @@ func (c *KafkaCluster) handleClaim(msg *msgClaimingPartition) {
 	topic.partitions[msg.PartID].InstanceID = msg.InstanceID
 	topic.partitions[msg.PartID].ClientID = msg.ClientID
 	topic.partitions[msg.PartID].GroupID = msg.GroupID
-	topic.partitions[msg.PartID].CurrentOffset = 0 // not present in this message, reset.
 	topic.partitions[msg.PartID].LastHeartbeat = int64(msg.Time)
 	topic.partitions[msg.PartID].LastRelease = 0
 }


### PR DESCRIPTION
I believe this line is responsible for consumer rewinding observed on several Marshal consumers lately. When a claim attempt writes to __marshal but then proceeds to fail (either to finish the claiming process or to issue the first heartbeat), this line of code causes the rationalizer in all subsequent claimers to believe that the current offset is 0 when really they ought to use the last current offset seen in a heartbeat message.

In the case where a claim succeeds, the rationalizer will observe the heartbeats which overwrite this 0 with the real current offset, as observed here:

```
I0719 22:08:19.026897 15141 log.go:32] O HAI: [goscribe.traffic-swoosh-squid:2] rationalize: releaseClaim(swoosh-ingestor-squid) start with CurrentOffset 63653613
I0719 22:08:19.026903 15141 log.go:32] O HAI: [goscribe.traffic-swoosh-squid:2] rationalize: releaseClaim(swoosh-ingestor-squid) exiting normally with CurrentOffset 63653613
I0719 22:08:19.027169 15141 log.go:32] O HAI: [goscribe.traffic-swoosh-squid:2] rationalize: handleClaim(swoosh-ingestor-squid) start with CurrentOffset 63653613
I0719 22:08:19.027351 15141 log.go:32] O HAI: [goscribe.traffic-swoosh-squid:2] rationalize: handleClaim(swoosh-ingestor-squid) exiting normally with CurrentOffset 0
I0719 22:08:19.027371 15141 log.go:32] O HAI: [goscribe.traffic-swoosh-squid:2] rationalize: updateClaim(swoosh-ingestor-squid) start with CurrentOffset 0
I0719 22:08:19.027376 15141 log.go:32] O HAI: [goscribe.traffic-swoosh-squid:2] rationalize: updateClaim(swoosh-ingestor-squid) exit with CurrentOffset 63653613
I0719 22:08:19.027451 15141 log.go:32] O HAI: [goscribe.traffic-swoosh-squid:2] rationalize: releaseClaim(swoosh-ingestor-squid) start with CurrentOffset 63653613
I0719 22:08:19.027457 15141 log.go:32] O HAI: [goscribe.traffic-swoosh-squid:2] rationalize: releaseClaim(swoosh-ingestor-squid) exiting normally with CurrentOffset 63653613
I0719 22:08:19.027592 15141 log.go:32] O HAI: [goscribe.traffic-swoosh-squid:2] rationalize: handleClaim(swoosh-ingestor-squid) start with CurrentOffset 63653613
I0719 22:08:19.027617 15141 log.go:32] O HAI: [goscribe.traffic-swoosh-squid:2] rationalize: handleClaim(swoosh-ingestor-squid) exiting normally with CurrentOffset 0
I0719 22:08:19.027904 15141 log.go:32] O HAI: [goscribe.traffic-swoosh-squid:2] rationalize: updateClaim(swoosh-ingestor-squid) start with CurrentOffset 0
I0719 22:08:19.027913 15141 log.go:32] O HAI: [goscribe.traffic-swoosh-squid:2] rationalize: updateClaim(swoosh-ingestor-squid) exit with CurrentOffset 63653613
I0719 22:08:19.028281 15141 log.go:32] O HAI: [goscribe.traffic-swoosh-squid:2] rationalize: updateClaim(swoosh-ingestor-squid) start with CurrentOffset 63653613
I0719 22:08:19.028286 15141 log.go:32] O HAI: [goscribe.traffic-swoosh-squid:2] rationalize: updateClaim(swoosh-ingestor-squid) exit with CurrentOffset 63661389
I0719 22:08:19.028644 15141 log.go:32] O HAI: [goscribe.traffic-swoosh-squid:2] rationalize: updateClaim(swoosh-ingestor-squid) start with CurrentOffset 63661389
I0719 22:08:19.028649 15141 log.go:32] O HAI: [goscribe.traffic-swoosh-squid:2] rationalize: updateClaim(swoosh-ingestor-squid) exit with CurrentOffset 63665435
```

Note that the offset is 0 temporarily but the heartbeat recovers the offset. Compare to the case where the claim fails:

```
I0719 22:08:20.541845 15141 log.go:32] O HAI: [goscribe.traffic-swoosh-squid:2] rationalize: releaseClaim(swoosh-ingestor-squid) start with CurrentOffset 65634730
I0719 22:08:20.541852 15141 log.go:32] O HAI: [goscribe.traffic-swoosh-squid:2] rationalize: releaseClaim(swoosh-ingestor-squid) exiting normally with CurrentOffset 65634730
I0719 22:08:20.541929 15141 log.go:32] O HAI: [goscribe.traffic-swoosh-squid:2] rationalize: handleClaim(swoosh-ingestor-squid) start with CurrentOffset 65634730
I0719 22:08:20.541936 15141 log.go:32] O HAI: [goscribe.traffic-swoosh-squid:2] rationalize: handleClaim(swoosh-ingestor-squid) exiting normally with CurrentOffset 0
I0719 22:08:20.542593 15141 log.go:32] O HAI: [goscribe.traffic-swoosh-squid:2] rationalize: handleClaim(swoosh-ingestor-squid) start with CurrentOffset 0
I0719 22:08:20.542600 15141 log.go:32] O HAI: [goscribe.traffic-swoosh-squid:2] rationalize: handleClaim(swoosh-ingestor-squid) exiting normally with CurrentOffset 0
I0719 22:08:20.542608 15141 log.go:32] O HAI: [goscribe.traffic-swoosh-squid:2] rationalize: handleClaim(swoosh-ingestor-squid) start with CurrentOffset 0
I0719 22:08:20.542615 15141 log.go:32] O HAI: [goscribe.traffic-swoosh-squid:2] rationalize: handleClaim(swoosh-ingestor-squid) exiting normally with CurrentOffset 0
I0719 22:08:20.542622 15141 log.go:32] O HAI: [goscribe.traffic-swoosh-squid:2] rationalize: updateClaim(swoosh-ingestor-squid) start with CurrentOffset 0
I0719 22:08:20.542628 15141 log.go:32] O HAI: [goscribe.traffic-swoosh-squid:2] rationalize: updateClaim(swoosh-ingestor-squid) exit with CurrentOffset 63863000
I0719 22:08:20.542780 15141 log.go:32] O HAI: [goscribe.traffic-swoosh-squid:2] rationalize: updateClaim(swoosh-ingestor-squid) start with CurrentOffset 63863000
I0719 22:08:20.542788 15141 log.go:32] O HAI: [goscribe.traffic-swoosh-squid:2] rationalize: updateClaim(swoosh-ingestor-squid) exit with CurrentOffset 63871619
I0719 22:08:20.542891 15141 log.go:32] O HAI: [goscribe.traffic-swoosh-squid:2] rationalize: updateClaim(swoosh-ingestor-squid) start with CurrentOffset 63871619
I0719 22:08:20.542898 15141 log.go:32] O HAI: [goscribe.traffic-swoosh-squid:2] rationalize: updateClaim(swoosh-ingestor-squid) exit with CurrentOffset 63877783
```

Here the second claimer believes the CurrentOffset is 0 which is then fast-forwarded to the earliest non-expired offset.

I claim this line is correct to delete because every rationalizer which reads it either:
* Already read a heartbeat message with a real CurrentOffset embedded, and it is always safe to resume consumption from a CurrentOffset which was heartbeated even if the Kafka committed offsets differ.
* Would need to fall through to Kafka committed offsets due to expiry of the __marshal topic, which will still happen because 0 is the zero value for CurrentOffset.

I believe this bug has existed since the dawn of time, but has mostly been non-impacting because Marshal attempts to fall back to Kafka committed offsets. However, all the recent offset related issues (SEV Arctic Bison) are also preventing Marshal from observing correct Kafka offsets so we fall all the way through to using earliest offset.