### PR TITLE
Fix marshal data race

### DIFF
--- a/marshal/claim.go
+++ b/marshal/claim.go
@@ -431,7 +431,7 @@ func (c *claim) updateCurrentOffsets() (bool, int64) {
 		// Remember current is always "last committed + 1", see the docs on
 		// PartitionOffset for a reminder.
 		didAdvance = true
-		if offset+1 <= c.offsets.Current  {
+		if offset+1 <= c.offsets.Current {
 			log.Errorf("[%s:%d] rewinding current offset from %d to %d",
 				c.topic, c.partID, c.offsets.Current, offset+1)
 		}


### PR DESCRIPTION
The data race is triggered because some partition claims are released in an asynchronous way. This allows the possibility where the offending channel is closed while there is a claim still trying to write to it.

Here we add a wait group for every asynchronous claim release, so as to ensure all claims are stopped
before we close the channel.
